### PR TITLE
feat: support AutoBinds as a meta-annotation for custom binding aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Add dependencies to your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.uandcode:hilt-autobind:0.1.1")
-    ksp("com.uandcode:hilt-autobind-compiler:0.1.1")
+    implementation("com.uandcode:hilt-autobind:0.2.0")
+    ksp("com.uandcode:hilt-autobind-compiler:0.2.0")
 }
 ```
 
@@ -61,13 +61,14 @@ Manual modules are not needed anymore, and Hilt can now inject `UserRepository` 
 
 ## Features
 
-| Feature                                              | Annotation / parameter      | Description                                                                         |
-|------------------------------------------------------|-----------------------------|-------------------------------------------------------------------------------------|
-| [Basic binding](docs/basic-usage.md)                 | `@AutoBinds`                | Generates `@Binds` modules for interface implementations                            |
-| [Scopes & components](docs/scopes-and-components.md) | `installIn`                 | Auto-detects or explicitly sets the Hilt component                                  |
-| [Class factory](docs/class-factory.md)               | `@AutoBinds(factory = ...)` | Delegates instance creation to a `ClassBindingFactory` (e.g., Retrofit)             |
-| [Delegate factory](docs/delegate-factory.md)         | `@AutoBinds(factory = ...)` | Provides a class and its sub-dependencies via `DelegateBindingFactory` (e.g., Room) |
-| [Multibinding](docs/multibinding.md)                 | `@AutoBindsIntoSet`         | Contributes to a Dagger `Set` multibinding                                          |
+| Feature                                              | Annotation / parameter          | Description                                                                         |
+|------------------------------------------------------|---------------------------------|-------------------------------------------------------------------------------------|
+| [Basic binding](docs/basic-usage.md)                 | `@AutoBinds`                    | Generates `@Binds` modules for interface implementations                            |
+| [Scopes & components](docs/scopes-and-components.md) | `installIn`                     | Auto-detects or explicitly sets the Hilt component                                  |
+| [Class factory](docs/class-factory.md)               | `@AutoBinds(factory = ...)`     | Delegates instance creation to a `ClassBindingFactory` (e.g., Retrofit)             |
+| [Delegate factory](docs/delegate-factory.md)         | `@AutoBinds(factory = ...)`     | Provides a class and its sub-dependencies via `DelegateBindingFactory` (e.g., Room) |
+| [Multibinding](docs/multibinding.md)                 | `@AutoBindsIntoSet`             | Contributes to a Dagger `Set` multibinding                                          |
+| [Annotation aliases](docs/annotation-aliases.md)     | `@AutoBinds` as meta-annotation | Define custom annotations that act as short aliases for `@AutoBinds`                |
 
 ## Requirements
 

--- a/docs/annotation-aliases.md
+++ b/docs/annotation-aliases.md
@@ -1,0 +1,176 @@
+# Annotation Aliases
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Defining an alias](#defining-an-alias)
+- [Forwarding installIn](#forwarding-installin)
+- [Forwarding a factory](#forwarding-a-factory)
+- [Multiple classes with one alias](#multiple-classes-with-one-alias)
+- [Requirements for alias annotations](#requirements-for-alias-annotations)
+
+## Overview
+
+When many classes share the same `@AutoBinds(factory = ...)` or `installIn`
+configuration, you can define a custom annotation that carries those parameters
+as defaults. Applying that annotation then has the same effect as applying
+`@AutoBinds` with the same arguments.
+
+This is useful for reducing boilerplate when binding many classes through a
+shared factory (e.g., Retrofit interfaces):
+
+```kotlin
+// Before
+@AutoBinds(factory = RetrofitBindingFactory::class)
+interface UserApi { /* ... */ }
+
+@AutoBinds(factory = RetrofitBindingFactory::class)
+interface PostApi { /* ... */ }
+
+// After
+@AutoBinds(factory = RetrofitBindingFactory::class)
+@Target(AnnotationTarget.CLASS)
+annotation class BindRetrofit
+
+@BindRetrofit
+interface UserApi { /* ... */ }
+
+@BindRetrofit
+interface PostApi { /* ... */ }
+```
+
+## Defining an Alias
+
+Annotate a Kotlin annotation class with `@AutoBinds` (and optionally any
+parameters you want to bake in). The alias must declare
+`@Target(AnnotationTarget.CLASS)` so it can be applied to classes and interfaces:
+
+```kotlin
+@Target(AnnotationTarget.CLASS)
+@AutoBinds
+annotation class MyBind
+```
+
+The processor detects this declaration and treats every class annotated with
+`@MyBind` as if it were annotated with `@AutoBinds` directly.
+
+## Forwarding installIn
+
+The `installIn` component is fixed in the alias and automatically applied to
+every class that uses it:
+
+```kotlin
+@Target(AnnotationTarget.CLASS)
+@AutoBinds(installIn = HiltComponent.Activity)
+annotation class BindToActivity
+```
+
+```kotlin
+@BindToActivity
+class MainPresenter @Inject constructor() : Presenter
+// same as: @AutoBinds(installIn = HiltComponent.Activity)
+```
+
+The annotated class can still carry a scope annotation. The processor validates
+that the scope is consistent with the `installIn` value, exactly as it does for
+direct `@AutoBinds` usage:
+
+```kotlin
+// OK: @ActivityScoped is consistent with installIn = Activity
+@BindToActivity
+@ActivityScoped
+class MainPresenter @Inject constructor() : Presenter
+
+// ERROR: @Singleton does not match installIn = Activity
+@BindToActivity
+@Singleton
+class MainPresenter @Inject constructor() : Presenter
+```
+
+If `installIn` is left at its default (`HiltComponent.Unspecified`), the
+processor auto-detects the component from the scope annotation on the annotated
+class, same as with direct `@AutoBinds`. See
+[Scopes and Components](scopes-and-components.md) for the full mapping.
+
+## Forwarding a Factory
+
+The `factory` parameter is forwarded to every class annotated with the alias,
+so each class produces a module that delegates to that factory:
+
+```kotlin
+class RetrofitBindingFactory @Inject constructor(
+    private val retrofit: Retrofit,
+) : ClassBindingFactory {
+
+    @AutoScoped
+    override fun <T : Any> create(kClass: KClass<T>): T {
+        return retrofit.create(kClass.java)
+    }
+}
+
+@Target(AnnotationTarget.CLASS)
+@AutoBinds(factory = RetrofitBindingFactory::class)
+annotation class BindRetrofit
+```
+
+```kotlin
+@BindRetrofit
+interface UserApi {
+    @GET("users/{id}")
+    suspend fun fetchUser(@Path("id") id: Long): UserDto
+}
+
+@BindRetrofit
+interface PostApi {
+    @GET("posts")
+    suspend fun getPosts(): List<PostDto>
+}
+```
+
+**Generated code** (one module per interface):
+
+```kotlin
+@Module
+@InstallIn(SingletonComponent::class)
+internal object UserApiModule {
+    @Provides
+    @Singleton
+    fun provideUserApi(factory: RetrofitBindingFactory): UserApi =
+        factory.create(UserApi::class)
+}
+```
+
+The alias works with all factory types: `ClassBindingFactory` (shown above) and
+`DelegateBindingFactory`. See [Class Factory](class-factory.md) and
+[Delegate Factory](delegate-factory.md) for details on each factory type.
+
+## Multiple Classes with One Alias
+
+All classes annotated with the same alias are processed independently. Each
+produces its own Hilt module:
+
+```kotlin
+@Target(AnnotationTarget.CLASS)
+@AutoBinds
+annotation class MyBind
+
+@MyBind
+class RepoAImpl @Inject constructor() : RepoA
+
+@MyBind
+class RepoBImpl @Inject constructor() : RepoBImpl
+```
+
+This generates `RepoAImplModule.kt` and `RepoBImplModule.kt` as separate files,
+just as if each class had `@AutoBinds` applied directly.
+
+## Requirements for Alias Annotations
+
+An annotation used as an `@AutoBinds` alias must:
+
+- Be an **annotation class** (declared with the `annotation class` keyword).
+- Declare **`@Target(AnnotationTarget.CLASS)`** so it can be applied to classes and interfaces.
+- Carry `@AutoBinds` (with any desired parameters) directly on its declaration.
+
+The processor emits a compile-time error if `@Target(AnnotationTarget.CLASS)` is
+missing.

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -117,6 +117,7 @@ A class annotated with `@AutoBinds` (in default mode, without a `factory`) must:
 
 - Be a **concrete class** (not an interface, object, or enum).
 - Be **non-abstract** (no `abstract` modifier).
+- **Not be an inner class** (no `inner` modifier).
 - Have a **primary constructor annotated with `@Inject`**.
 - Implement **at least one interface**.
 

--- a/docs/delegate-factory.md
+++ b/docs/delegate-factory.md
@@ -104,13 +104,22 @@ Both `AppDatabase` and all its DAOs become injectable with a single annotation.
 
 ## Factory Requirements
 
-A `DelegateBindingFactory` subclass must be:
+A `DelegateBindingFactory` subclass must:
 
-- A **final class** (no `open` or `abstract` modifier, not an `object`).
-- Free of **type parameters** (specify the concrete type on the parent, e.g.,
+- Be a **final class** (no `open` or `abstract` modifier, not an `object`).
+- Be free of **type parameters** (specify the concrete type on the parent, e.g.,
   `DelegateBindingFactory<AppDatabase>`).
 - Have a **primary constructor annotated with `@Inject`**.
-- **Directly implement** `DelegateBindingFactory` (not through an intermediate
-  class).
+- **Directly implement** `DelegateBindingFactory` (not through an intermediate class).
+- **Declare `provideDelegate()` with `override`** directly in the factory class body —
+  an inherited implementation is not sufficient.
+- Have `provideDelegate()` **return the annotated class type** exactly (e.g., if
+  `@AutoBinds(factory = MyDbFactory::class)` is on `AppDatabase`, then
+  `provideDelegate()` must return `AppDatabase`).
+
+The annotated class itself must also:
+
+- Be free of **type parameters** (generic annotated classes are not supported with
+  `DelegateBindingFactory`).
 
 The processor emits a compile-time error if any of these conditions are not met.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,8 +40,8 @@ Add the runtime library and the KSP compiler to your module's `build.gradle.kts`
 
 ```kotlin
 dependencies {
-    implementation("com.uandcode:hilt-autobind:0.1.1")
-    ksp("com.uandcode:hilt-autobind-compiler:0.1.1")
+    implementation("com.uandcode:hilt-autobind:0.2.0")
+    ksp("com.uandcode:hilt-autobind-compiler:0.2.0")
 }
 ```
 
@@ -51,7 +51,7 @@ If your project uses a Gradle version catalog (`libs.versions.toml`):
 
 ```toml
 [versions]
-hiltAutoBind = "0.1.1"
+hiltAutoBind = "0.2.0"
 
 [libraries]
 hilt-autobind = { module = "com.uandcode:hilt-autobind", version.ref = "hiltAutoBind" }

--- a/docs/multibinding.md
+++ b/docs/multibinding.md
@@ -86,5 +86,5 @@ internal interface LoggingInterceptor__IntoSetModule {
 ```
 
 The same class requirements as [basic usage](basic-usage.md#requirements-for-annotated-classes)
-apply: the class must be concrete, non-abstract, final, have `@Inject` on its
+apply: the class must be concrete, non-abstract, not an inner class, have `@Inject` on its
 primary constructor, and implement at least one interface.

--- a/gradle-public.properties
+++ b/gradle-public.properties
@@ -5,7 +5,7 @@ android.useAndroidX=true
 
 # Maven Central publishing coordinates
 GROUP=com.uandcode
-VERSION_NAME=0.1.1
+VERSION_NAME=0.2.0
 
 # POM metadata
 POM_DESCRIPTION=Auto-generate Hilt binding modules with a single annotation

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/AnnotatedSymbolsResolver.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/AnnotatedSymbolsResolver.kt
@@ -1,0 +1,276 @@
+@file:OptIn(KspExperimental::class)
+
+package com.uandcode.hilt.autobind.compiler
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.getAnnotationsByType
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.validate
+import com.uandcode.hilt.autobind.AutoBinds
+import com.uandcode.hilt.autobind.AutoBindsIntoSet
+import com.uandcode.hilt.autobind.factories.ClassBindingFactory
+import com.uandcode.hilt.autobind.factories.DelegateBindingFactory
+import com.uandcode.hilt.autobind.factories.NoOpBindingFactory
+import kotlin.reflect.KClass
+
+internal class AnnotatedSymbolsResolver(
+    private val logger: KSPLogger,
+    private val componentResolver: HiltComponentResolver,
+) {
+
+    fun processAnnotatedSymbols(
+        resolver: Resolver,
+        handler: (ModuleType, ModuleInfo) -> Unit,
+    ): List<KSAnnotated> {
+        val deferred = mutableListOf<KSAnnotated>()
+        deferred += processAutoBindsSymbols(resolver, handler)
+        deferred += processAutoBindsIntoSet(resolver, handler)
+        return deferred
+    }
+
+    /**
+     * Finds all symbols annotated with [@AutoBinds] and routes them:
+     * - Annotation class declarations → treated as meta-annotation aliases (processed via
+     *   [processMetaAutoBinds])
+     * - All other class declarations → processed normally via [processAutoBinds]
+     */
+    private fun processAutoBindsSymbols(
+        resolver: Resolver,
+        handler: (ModuleType, ModuleInfo) -> Unit,
+    ): List<KSAnnotated> {
+        val symbols = resolver
+            .getSymbolsWithAnnotation(requireNotNull(AutoBinds::class.qualifiedName))
+            .filterIsInstance<KSClassDeclaration>()
+            .toList()
+
+        val deferred = mutableListOf<KSAnnotated>()
+        for (symbol in symbols) {
+            if (!symbol.validate()) {
+                deferred.add(symbol)
+                continue
+            }
+            if (symbol.classKind == ClassKind.ANNOTATION_CLASS) {
+                deferred += processMetaAutoBinds(resolver, symbol, handler)
+            } else {
+                processAutoBinds(
+                    annotatedClass = symbol,
+                    originAnnotationName = requireNotNull(AutoBinds::class.simpleName),
+                    handler = handler,
+                )
+            }
+        }
+        return deferred
+    }
+
+    /**
+     * Handles a user-defined annotation class that carries [@AutoBinds] as a meta-annotation.
+     *
+     * Validates that the annotation targets [AnnotationTarget.CLASS], then finds all classes
+     * annotated with it and processes each one using the [@AutoBinds] parameters defined on
+     * the meta-annotation declaration.
+     */
+    private fun processMetaAutoBinds(
+        resolver: Resolver,
+        metaAnnotation: KSClassDeclaration,
+        handler: (ModuleType, ModuleInfo) -> Unit,
+    ): List<KSAnnotated> {
+        if (!metaAnnotation.targetsClass()) {
+            logger.error(
+                "@AutoBinds meta-annotation '@${metaAnnotation.simpleName.asString()}' must declare " +
+                        "@Target(AnnotationTarget.CLASS) to be applied to classes.",
+                metaAnnotation,
+            )
+            return emptyList()
+        }
+
+        val qualifiedName = metaAnnotation.qualifiedName?.asString() ?: return emptyList()
+        val deferred = mutableListOf<KSAnnotated>()
+
+        val symbols = resolver
+            .getSymbolsWithAnnotation(qualifiedName)
+            .filterIsInstance<KSClassDeclaration>()
+            .toList()
+
+        for (symbol in symbols) {
+            if (!symbol.validate()) {
+                deferred.add(symbol)
+                continue
+            }
+            processAutoBinds(
+                annotatedClass = symbol,
+                annotationSource = metaAnnotation,
+                originAnnotationName = metaAnnotation.simpleName.asString(),
+                handler = handler,
+            )
+        }
+        return deferred
+    }
+
+    private fun processAutoBindsIntoSet(
+        resolver: Resolver,
+        handler: (ModuleType, ModuleInfo) -> Unit,
+    ): List<KSAnnotated> {
+        val symbols = resolver
+            .getSymbolsWithAnnotation(requireNotNull(AutoBindsIntoSet::class.qualifiedName))
+            .filterIsInstance<KSClassDeclaration>()
+            .toList()
+
+        val deferred = mutableListOf<KSAnnotated>()
+        for (symbol in symbols) {
+            if (!symbol.validate()) {
+                deferred.add(symbol)
+                continue
+            }
+            processAutoBindsIntoSet(symbol, handler)
+        }
+        return deferred
+    }
+
+    /**
+     * Processes a class annotated (directly or via a meta-annotation) with [@AutoBinds].
+     *
+     * @param annotatedClass The class for which a Hilt module will be generated.
+     * @param annotationSource The declaration from which [@AutoBinds] arguments are read.
+     *   Defaults to [annotatedClass] for the direct-annotation case; set to the
+     *   meta-annotation declaration when the annotation was applied indirectly.
+     */
+    private fun processAutoBinds(
+        annotatedClass: KSClassDeclaration,
+        handler: (ModuleType, ModuleInfo) -> Unit,
+        originAnnotationName: String,
+        annotationSource: KSClassDeclaration = annotatedClass,
+    ) {
+        val annotation = annotationSource
+            .getAnnotationsByType(AutoBinds::class)
+            .firstOrNull()
+        if (annotation == null) {
+            logger.error(
+                "Can't find AutoBinds annotation for class ${annotatedClass.simpleName}",
+                annotatedClass,
+            )
+            return
+        }
+
+        val resolved = componentResolver.resolve(
+            declaredComponent = annotation.installIn,
+            annotatedClass = annotatedClass,
+            annotationName = AUTOBINDS_NAME,
+        ) ?: return
+
+        val moduleInfo = ModuleInfo(
+            annotatedClass = annotatedClass,
+            hiltComponentClassName = resolved.hiltComponentClassName,
+            scopeClassName = resolved.scopeClassName,
+            annotationSource = annotationSource,
+            annotationName = originAnnotationName,
+        )
+        val moduleType = getModuleType(annotationSource)
+        if (moduleType != null) {
+            handler.invoke(moduleType, moduleInfo)
+        }
+    }
+
+    private fun processAutoBindsIntoSet(
+        annotatedClass: KSClassDeclaration,
+        handler: (ModuleType, ModuleInfo) -> Unit,
+    ) {
+        val annotation = annotatedClass
+            .getAnnotationsByType(AutoBindsIntoSet::class)
+            .firstOrNull() ?: run {
+                logger.error(
+                    "Can't find AutoBindsIntoSet annotation for class ${annotatedClass.simpleName}",
+                    annotatedClass
+                )
+                return
+            }
+
+        val resolved = componentResolver.resolve(
+            declaredComponent = annotation.installIn,
+            annotatedClass = annotatedClass,
+            annotationName = AUTOBINDS_INTO_SET_NAME,
+        ) ?: return
+
+        val moduleInfo = ModuleInfo(
+            annotatedClass = annotatedClass,
+            hiltComponentClassName = resolved.hiltComponentClassName,
+            scopeClassName = resolved.scopeClassName,
+            annotationSource = annotatedClass,
+            moduleNameSuffix = "__IntoSetModule",
+            annotationName = requireNotNull(AutoBindsIntoSet::class.simpleName)
+        )
+        handler.invoke(ModuleType.IntoSet, moduleInfo)
+    }
+
+    /**
+     * Determines the module generation strategy by reading the `factory` annotation argument.
+     *
+     * Note: reading the `factory` argument via raw KSP annotation/arguments API instead of
+     * [getAnnotationsByType] because the latter returns a Kotlin [KClass] which cannot be
+     * inspected for supertypes. We need the [KSType] to check if the factory implements
+     * [ClassBindingFactory].
+     *
+     * @param annotationSource The declaration that holds the [@AutoBinds] annotation
+     *   (either the annotated class itself or a meta-annotation declaration).
+     */
+    private fun getModuleType(annotationSource: KSClassDeclaration): ModuleType? {
+        return findFactoryKType(annotationSource)
+            ?.let { it.declaration as? KSClassDeclaration }
+            ?.takeIf { it.qualifiedName?.asString() != NoOpBindingFactory::class.qualifiedName }
+            ?.let { factoryDeclaration ->
+                val superTypeNames = factoryDeclaration.superTypes
+                    .map { it.resolve().declaration.qualifiedName?.asString() }
+                    .toList()
+                if (ClassBindingFactory::class.qualifiedName in superTypeNames) {
+                    ModuleType.ClassFactory(factoryDeclaration)
+                } else if (DelegateBindingFactory::class.qualifiedName in superTypeNames) {
+                    ModuleType.DelegateFactory(factoryDeclaration)
+                } else {
+                    logger.error(
+                        "AutoBinds Factory class '${factoryDeclaration.simpleName.asString()}' " +
+                                "must directly implement ClassBindingFactory or DelegateBindingFactory",
+                        factoryDeclaration,
+                    )
+                    return null
+                }
+            } ?: ModuleType.Default
+    }
+
+    private fun findFactoryKType(annotationSource: KSClassDeclaration): KSType? {
+        return annotationSource
+            .annotations
+            .firstOrNull { it.shortName.asString() == AUTOBINDS_NAME }
+            ?.arguments
+            ?.firstOrNull { it.name?.asString() == FACTORY_ARG_NAME }
+            ?.value as? KSType
+    }
+
+    /**
+     * Returns true if this annotation declaration has [@Target] that includes
+     * [AnnotationTarget.CLASS].
+     */
+    private fun KSClassDeclaration.targetsClass(): Boolean {
+        val targetAnnotation = annotations.firstOrNull {
+            it.shortName.asString() == "Target"
+        } ?: return false
+
+        @Suppress("UNCHECKED_CAST")
+        val targetList = targetAnnotation.arguments
+            .firstOrNull()
+            ?.value as? List<*>
+            ?: return false
+
+        return (targetList.singleOrNull() as? KSClassDeclaration)
+            ?.qualifiedName?.asString() == "kotlin.annotation.AnnotationTarget.CLASS"
+    }
+
+    private companion object {
+        const val AUTOBINDS_NAME = "AutoBinds"
+        const val AUTOBINDS_INTO_SET_NAME = "AutoBindsIntoSet"
+        const val FACTORY_ARG_NAME = "factory"
+    }
+}

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/AutoBindingSymbolProcessor.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/AutoBindingSymbolProcessor.kt
@@ -3,25 +3,19 @@
 package com.uandcode.hilt.autobind.compiler
 
 import com.google.devtools.ksp.KspExperimental
-import com.google.devtools.ksp.getAnnotationsByType
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
-import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.google.devtools.ksp.symbol.KSType
-import com.google.devtools.ksp.validate
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.ksp.writeTo
-import com.uandcode.hilt.autobind.AutoBinds
-import com.uandcode.hilt.autobind.AutoBindsIntoSet
-import com.uandcode.hilt.autobind.factories.ClassBindingFactory
-import com.uandcode.hilt.autobind.factories.DelegateBindingFactory
-import com.uandcode.hilt.autobind.factories.NoOpBindingFactory
-import kotlin.reflect.KClass
+import com.uandcode.hilt.autobind.compiler.generators.ClassFactoryModuleGenerator
+import com.uandcode.hilt.autobind.compiler.generators.DefaultModuleGenerator
+import com.uandcode.hilt.autobind.compiler.generators.DelegateFactoryModuleGenerator
+import com.uandcode.hilt.autobind.compiler.generators.IntoSetModuleGenerator
 
 class AutoBindingSymbolProcessor(
     private val logger: KSPLogger,
@@ -34,116 +28,53 @@ class AutoBindingSymbolProcessor(
     private val delegateFactoryModuleGenerator = DelegateFactoryModuleGenerator(logger)
     private val intoSetModuleGenerator = IntoSetModuleGenerator(logger)
 
+    private val annotatedSymbolsResolver = AnnotatedSymbolsResolver(
+        logger, componentResolver,
+    )
+
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        val deferred = mutableListOf<KSAnnotated>()
-        deferred += processAnnotation<AutoBinds>(resolver) { processAutoBinds(it) }
-        deferred += processAnnotation<AutoBindsIntoSet>(resolver) { processAutoBindsIntoSet(it) }
-        return deferred
-    }
-
-    private inline fun <reified T : Annotation> processAnnotation(
-        resolver: Resolver,
-        crossinline handler: (KSClassDeclaration) -> Unit,
-    ): List<KSAnnotated> {
-        val symbols = resolver
-            .getSymbolsWithAnnotation(requireNotNull(T::class.qualifiedName))
-            .filterIsInstance<KSClassDeclaration>()
-            .toList()
-
-        val deferred = mutableListOf<KSAnnotated>()
-        for (symbol in symbols) {
-            if (!symbol.validate()) {
-                deferred.add(symbol)
-                continue
-            }
-            handler(symbol)
-        }
-        return deferred
-    }
-
-    private fun processAutoBinds(annotatedClass: KSClassDeclaration) {
-        val annotation = annotatedClass
-            .getAnnotationsByType(AutoBinds::class)
-            .firstOrNull()
-        if (annotation == null) {
-            logger.error("Can't find AutoBinds annotation for class ${annotatedClass.simpleName}", annotatedClass)
-            return
-        }
-
-        val resolved = componentResolver.resolve(
-            declaredComponent = annotation.installIn,
-            annotatedClass = annotatedClass,
-            annotationName = AUTOBINDS_NAME,
-        ) ?: return
-
-        val moduleInfo = ModuleInfo(
-            annotatedClass = annotatedClass,
-            hiltComponentClassName = resolved.hiltComponentClassName,
-            scopeClassName = resolved.scopeClassName,
+        return annotatedSymbolsResolver.processAnnotatedSymbols(
+            resolver = resolver,
+            handler = ::buildHiltModule,
         )
+    }
 
-        val hiltModuleTypeSpec = when (val moduleType = getModuleType(annotatedClass)) {
+    private fun buildHiltModule(type: ModuleType, moduleInfo: ModuleInfo) {
+        val typeSpec = when (type) {
+            is ModuleType.Default -> defaultModuleGenerator.generate(moduleInfo)
+            is ModuleType.IntoSet -> intoSetModuleGenerator.generate(moduleInfo)
             is ModuleType.ClassFactory -> classFactoryModuleGenerator.generate(
                 moduleInfo = moduleInfo,
-                factoryDeclaration = moduleType.factoryDeclaration,
+                factoryDeclaration = type.factoryDeclaration,
             )
             is ModuleType.DelegateFactory -> delegateFactoryModuleGenerator.generate(
                 moduleInfo = moduleInfo,
-                annotatedClass = annotatedClass,
-                factoryDeclaration = moduleType.factoryDeclaration,
+                factoryDeclaration = type.factoryDeclaration,
             )
-            ModuleType.Default -> defaultModuleGenerator.generate(
-                moduleInfo = moduleInfo,
-                targetInterfaces = annotatedClass.getTargetInterfaces(),
-            )
-            null -> null
         }
 
-        writeModule(hiltModuleTypeSpec, moduleInfo, annotatedClass)
-    }
-
-    private fun processAutoBindsIntoSet(annotatedClass: KSClassDeclaration) {
-        val annotation = annotatedClass
-            .getAnnotationsByType(AutoBindsIntoSet::class)
-            .firstOrNull() ?: run {
-                logger.error(
-                    "Can't find AutoBindsIntoSet annotation for class ${annotatedClass.simpleName}",
-                    annotatedClass
-                )
-                return
-            }
-
-        val resolved = componentResolver.resolve(
-            declaredComponent = annotation.installIn,
-            annotatedClass = annotatedClass,
-            annotationName = AUTOBINDS_INTO_SET_NAME,
-        ) ?: return
-
-        val moduleInfo = ModuleInfo(
-            annotatedClass = annotatedClass,
-            hiltComponentClassName = resolved.hiltComponentClassName,
-            scopeClassName = resolved.scopeClassName,
-            moduleNameSuffix = "__IntoSetModule",
-        )
-
-        val hiltModuleTypeSpec = intoSetModuleGenerator.generate(
-            moduleInfo = moduleInfo,
-            targetInterfaces = annotatedClass.getTargetInterfaces(),
-        )
-
-        writeModule(hiltModuleTypeSpec, moduleInfo, annotatedClass)
+        if (typeSpec != null) {
+            writeModule(
+                hiltModuleTypeSpec = typeSpec,
+                moduleInfo = moduleInfo,
+            )
+        }
     }
 
     private fun writeModule(
         hiltModuleTypeSpec: com.squareup.kotlinpoet.TypeSpec?,
         moduleInfo: ModuleInfo,
-        annotatedClass: KSClassDeclaration,
+        annotationSource: KSClassDeclaration = moduleInfo.annotationSource,
     ) {
         if (hiltModuleTypeSpec != null) {
             val fileSpec = FileSpec.builder(moduleInfo.moduleClassName)
                 .addType(hiltModuleTypeSpec)
                 .build()
-            val sources = listOfNotNull(annotatedClass.containingFile)
+            val sources = listOfNotNull(
+                moduleInfo.annotatedClass.containingFile,
+                annotationSource.containingFile.takeIf { it != moduleInfo.annotatedClass
+                    .containingFile },
+            )
             fileSpec.writeTo(
                 codeGenerator = codeGenerator,
                 dependencies = Dependencies(
@@ -154,56 +85,4 @@ class AutoBindingSymbolProcessor(
         }
     }
 
-    /**
-     * Determines the module generation strategy by reading the `factory` annotation argument.
-     *
-     * Note: reading the `factory` argument via raw KSP annotation/arguments API instead of
-     * [getAnnotationsByType] because the latter returns a Kotlin [KClass] which cannot be
-     * inspected for supertypes. We need the [KSType] to check if the factory implements
-     * [ClassBindingFactory].
-     */
-    private fun getModuleType(annotatedClass: KSClassDeclaration): ModuleType? {
-        return findFactoryKType(annotatedClass)
-            ?.let { it.declaration as? KSClassDeclaration }
-            ?.takeIf { it.qualifiedName?.asString() != NoOpBindingFactory::class.qualifiedName }
-            ?.let { factoryDeclaration ->
-                val superTypeNames = factoryDeclaration.superTypes
-                    .map { it.resolve().declaration.qualifiedName?.asString() }
-                    .toList()
-                if (ClassBindingFactory::class.qualifiedName in superTypeNames) {
-                    ModuleType.ClassFactory(factoryDeclaration)
-                } else if (DelegateBindingFactory::class.qualifiedName in superTypeNames) {
-                    ModuleType.DelegateFactory(factoryDeclaration)
-                } else {
-                    logger.error(
-                        "AutoBinds Factory class '${factoryDeclaration.simpleName.asString()}' " +
-                                "must directly implement ClassBindingFactory or DelegateBindingFactory",
-                        factoryDeclaration,
-                    )
-                    return null
-                }
-            } ?: ModuleType.Default
-    }
-
-    private fun KSClassDeclaration.getTargetInterfaces(): List<KSType> {
-        return superTypes
-            .map { it.resolve() }
-            .filter { (it.declaration as? KSClassDeclaration)?.classKind == ClassKind.INTERFACE }
-            .toList()
-    }
-
-    private fun findFactoryKType(annotatedClass: KSClassDeclaration): KSType? {
-        return annotatedClass
-            .annotations
-            .firstOrNull { it.shortName.asString() == AUTOBINDS_NAME }
-            ?.arguments
-            ?.firstOrNull { it.name?.asString() == FACTORY_ARG_NAME }
-            ?.value as? KSType
-    }
-
-    private companion object {
-        const val AUTOBINDS_NAME = "AutoBinds"
-        const val AUTOBINDS_INTO_SET_NAME = "AutoBindsIntoSet"
-        const val FACTORY_ARG_NAME = "factory"
-    }
 }

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/ModuleInfo.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/ModuleInfo.kt
@@ -11,6 +11,8 @@ internal class ModuleInfo(
     val annotatedClass: KSClassDeclaration,
     val hiltComponentClassName: ClassName,
     val scopeClassName: ClassName,
+    val annotationName: String,
+    val annotationSource: KSClassDeclaration,
     moduleNameSuffix: String = "Module",
 ) {
     val originClassName: ClassName = annotatedClass.toClassName()

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/ModuleType.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/ModuleType.kt
@@ -6,8 +6,12 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
  * Represents the kind of Hilt module to generate.
  */
 internal sealed class ModuleType {
+
     /** Generate an interface with `@Binds` functions. */
     data object Default : ModuleType()
+
+    /** Generate an interface with `@Binds` and `@IntoSet` functions. */
+    data object IntoSet : ModuleType()
 
     /** Generate an object with a `@Provides` function that delegates to a factory. */
     data class ClassFactory(
@@ -18,4 +22,5 @@ internal sealed class ModuleType {
     data class DelegateFactory(
         val factoryDeclaration: KSClassDeclaration,
     ) : ModuleType()
+
 }

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/AbstractModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/AbstractModuleGenerator.kt
@@ -1,4 +1,4 @@
-package com.uandcode.hilt.autobind.compiler
+package com.uandcode.hilt.autobind.compiler.generators
 
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSClassDeclaration
@@ -6,14 +6,13 @@ import com.google.devtools.ksp.symbol.KSType
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
-import com.uandcode.hilt.autobind.AutoBinds
+import com.uandcode.hilt.autobind.compiler.ModuleInfo
 
-abstract class AbstractModuleGenerator(
+internal abstract class AbstractModuleGenerator(
     protected val logger: KSPLogger,
-    private val annotationName: String = requireNotNull(AutoBinds::class.simpleName),
 ) {
 
-    protected fun logError(message: String, annotatedClass: KSClassDeclaration) {
+    protected fun ModuleInfo.logError(message: String, annotatedClass: KSClassDeclaration) {
         logger.error(
             message = "The class '${annotatedClass.simpleName.asString()}' annotated with " +
                     "@$annotationName annotation $message",
@@ -22,10 +21,10 @@ abstract class AbstractModuleGenerator(
     }
 
     protected fun forEachTargetInterface(
-        annotatedClass: KSClassDeclaration,
+        moduleInfo: ModuleInfo,
         targetInterfaces: List<KSType>,
         block: (TargetInterface) -> Unit,
-    ) {
+    ) = with(moduleInfo) {
         val classNames = targetInterfaces.mapNotNull { (it.declaration as? KSClassDeclaration)?.toClassName() }
         if (classNames.isEmpty()) {
             logNoImplementedInterfaces(annotatedClass)
@@ -48,7 +47,7 @@ abstract class AbstractModuleGenerator(
         }
     }
 
-    protected fun logNoImplementedInterfaces(annotatedClass: KSClassDeclaration) {
+    protected fun ModuleInfo.logNoImplementedInterfaces(annotatedClass: KSClassDeclaration) {
         logError("must implement at least one interface", annotatedClass)
     }
 

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/ClassFactoryModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/ClassFactoryModuleGenerator.kt
@@ -1,6 +1,6 @@
 @file:OptIn(KspExperimental::class)
 
-package com.uandcode.hilt.autobind.compiler
+package com.uandcode.hilt.autobind.compiler.generators
 
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getDeclaredFunctions
@@ -11,6 +11,7 @@ import com.google.devtools.ksp.symbol.Modifier
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.ksp.toClassName
+import com.uandcode.hilt.autobind.compiler.ModuleInfo
 import com.uandcode.hilt.autobind.factories.AutoScoped
 import com.uandcode.hilt.autobind.factories.ClassBindingFactory
 import dagger.Provides

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/DefaultModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/DefaultModuleGenerator.kt
@@ -1,41 +1,31 @@
 @file:OptIn(KspExperimental::class)
 
-package com.uandcode.hilt.autobind.compiler
+package com.uandcode.hilt.autobind.compiler.generators
 
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.isAbstract
 import com.google.devtools.ksp.isAnnotationPresent
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.ClassKind
-import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.Modifier
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeSpec
-import com.uandcode.hilt.autobind.AutoBindsIntoSet
+import com.uandcode.hilt.autobind.compiler.ModuleInfo
 import dagger.Binds
-import dagger.multibindings.IntoSet
 import javax.inject.Inject
 
 /**
- * Generates an interface-based Hilt module with `@Binds @IntoSet` functions
- * for each directly implemented interface, contributing the class to a
- * multibinding `Set`.
+ * Generates an interface-based Hilt module with `@Binds` functions
+ * for each directly implemented interface.
  */
-internal class IntoSetModuleGenerator(
+internal class DefaultModuleGenerator(
     logger: KSPLogger,
-) : AbstractModuleGenerator(
-    logger = logger,
-    annotationName = requireNotNull(AutoBindsIntoSet::class.simpleName),
-) {
+) : AbstractModuleGenerator(logger) {
 
-    fun generate(
-        moduleInfo: ModuleInfo,
-        targetInterfaces: List<KSType>,
-    ): TypeSpec? = with(moduleInfo) {
-
+    fun generate(moduleInfo: ModuleInfo): TypeSpec? = with(moduleInfo) {
         if (annotatedClass.classKind != ClassKind.CLASS) {
             logError("must be a class (not object, interface, etc.)", annotatedClass)
             return null
@@ -46,13 +36,14 @@ internal class IntoSetModuleGenerator(
             return null
         }
 
+        val targetInterfaces = annotatedClass.getTargetInterfaces()
         if (targetInterfaces.isEmpty()) {
-            logError("must implement at least one interface", annotatedClass)
+            logNoImplementedInterfaces(annotatedClass)
             return null
         }
 
         if (annotatedClass.isAbstract()) {
-            logError("must be a final non-abstract class", annotatedClass)
+            logError("must be a non-abstract class", annotatedClass)
             return null
         }
 
@@ -68,20 +59,19 @@ internal class IntoSetModuleGenerator(
             .interfaceBuilder(className = moduleClassName)
             .applyHiltModuleAnnotationsAndModifiers(hiltComponentClassName)
             .apply {
-                addBindIntoSetFunctions(annotatedClass, originClassName, targetInterfaces)
+                addBindFunctions(moduleInfo, originClassName, targetInterfaces)
             }
             .build()
     }
 
-    private fun TypeSpec.Builder.addBindIntoSetFunctions(
-        annotatedClass: KSClassDeclaration,
+    private fun TypeSpec.Builder.addBindFunctions(
+        moduleInfo: ModuleInfo,
         originClassName: ClassName,
         targetInterfaces: List<KSType>,
-    ) = forEachTargetInterface(annotatedClass, targetInterfaces) {
+    ) = forEachTargetInterface(moduleInfo, targetInterfaces) {
         val funSpec = FunSpec.builder(it.functionName)
             .addParameter(name = "impl", type = originClassName)
             .addAnnotation(Binds::class)
-            .addAnnotation(IntoSet::class)
             .addModifiers(KModifier.ABSTRACT)
             .returns(it.interfaceTypeName)
             .build()

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/DelegateFactoryModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/DelegateFactoryModuleGenerator.kt
@@ -1,6 +1,6 @@
 @file:OptIn(KspExperimental::class)
 
-package com.uandcode.hilt.autobind.compiler
+package com.uandcode.hilt.autobind.compiler.generators
 
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.isAbstract
@@ -17,6 +17,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
+import com.uandcode.hilt.autobind.compiler.ModuleInfo
 import com.uandcode.hilt.autobind.factories.AutoScoped
 import com.uandcode.hilt.autobind.factories.DelegateBindingFactory
 import dagger.Provides
@@ -35,11 +36,10 @@ internal class DelegateFactoryModuleGenerator(
 
     fun generate(
         moduleInfo: ModuleInfo,
-        annotatedClass: KSClassDeclaration,
         factoryDeclaration: KSClassDeclaration,
     ): TypeSpec? = with(moduleInfo) {
 
-        if (!validateFactory(factoryDeclaration, annotatedClass)) return null
+        if (!validateFactory(factoryDeclaration, moduleInfo.annotatedClass)) return null
 
         val factoryClassName = factoryDeclaration.toClassName()
 
@@ -106,7 +106,7 @@ internal class DelegateFactoryModuleGenerator(
     }
 
     @Suppress("ReturnCount")
-    private fun validateFactory(
+    private fun ModuleInfo.validateFactory(
         factoryDeclaration: KSClassDeclaration,
         annotatedClass: KSClassDeclaration,
     ): Boolean {

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/HiltModuleAnnotations.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/HiltModuleAnnotations.kt
@@ -1,4 +1,4 @@
-package com.uandcode.hilt.autobind.compiler
+package com.uandcode.hilt.autobind.compiler.generators
 
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/IntoSetModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/IntoSetModuleGenerator.kt
@@ -1,34 +1,33 @@
 @file:OptIn(KspExperimental::class)
 
-package com.uandcode.hilt.autobind.compiler
+package com.uandcode.hilt.autobind.compiler.generators
 
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.isAbstract
 import com.google.devtools.ksp.isAnnotationPresent
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.ClassKind
-import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.Modifier
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeSpec
+import com.uandcode.hilt.autobind.compiler.ModuleInfo
 import dagger.Binds
+import dagger.multibindings.IntoSet
 import javax.inject.Inject
 
 /**
- * Generates an interface-based Hilt module with `@Binds` functions
- * for each directly implemented interface.
+ * Generates an interface-based Hilt module with `@Binds @IntoSet` functions
+ * for each directly implemented interface, contributing the class to a
+ * multibinding `Set`.
  */
-internal class DefaultModuleGenerator(
+internal class IntoSetModuleGenerator(
     logger: KSPLogger,
-) : AbstractModuleGenerator(logger) {
+) : AbstractModuleGenerator(logger = logger) {
 
-    fun generate(
-        moduleInfo: ModuleInfo,
-        targetInterfaces: List<KSType>,
-    ): TypeSpec? = with(moduleInfo) {
+    fun generate(moduleInfo: ModuleInfo): TypeSpec? = with(moduleInfo) {
 
         if (annotatedClass.classKind != ClassKind.CLASS) {
             logError("must be a class (not object, interface, etc.)", annotatedClass)
@@ -40,13 +39,14 @@ internal class DefaultModuleGenerator(
             return null
         }
 
+        val targetInterfaces = annotatedClass.getTargetInterfaces()
         if (targetInterfaces.isEmpty()) {
-            logNoImplementedInterfaces(annotatedClass)
+            logError("must implement at least one interface", annotatedClass)
             return null
         }
 
         if (annotatedClass.isAbstract()) {
-            logError("must be a non-abstract class", annotatedClass)
+            logError("must be a final non-abstract class", annotatedClass)
             return null
         }
 
@@ -62,19 +62,20 @@ internal class DefaultModuleGenerator(
             .interfaceBuilder(className = moduleClassName)
             .applyHiltModuleAnnotationsAndModifiers(hiltComponentClassName)
             .apply {
-                addBindFunctions(annotatedClass, originClassName, targetInterfaces)
+                addBindIntoSetFunctions(moduleInfo, originClassName, targetInterfaces)
             }
             .build()
     }
 
-    private fun TypeSpec.Builder.addBindFunctions(
-        annotatedClass: KSClassDeclaration,
+    private fun TypeSpec.Builder.addBindIntoSetFunctions(
+        moduleInfo: ModuleInfo,
         originClassName: ClassName,
         targetInterfaces: List<KSType>,
-    ) = forEachTargetInterface(annotatedClass, targetInterfaces) {
+    ) = forEachTargetInterface(moduleInfo, targetInterfaces) {
         val funSpec = FunSpec.builder(it.functionName)
             .addParameter(name = "impl", type = originClassName)
             .addAnnotation(Binds::class)
+            .addAnnotation(IntoSet::class)
             .addModifiers(KModifier.ABSTRACT)
             .returns(it.interfaceTypeName)
             .build()

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/KspClassDeclarationExtensions.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/KspClassDeclarationExtensions.kt
@@ -1,0 +1,12 @@
+package com.uandcode.hilt.autobind.compiler.generators
+
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSType
+
+internal fun KSClassDeclaration.getTargetInterfaces(): List<KSType> {
+    return superTypes
+        .map { it.resolve() }
+        .filter { (it.declaration as? KSClassDeclaration)?.classKind == ClassKind.INTERFACE }
+        .toList()
+}

--- a/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/HiltComponentResolverTest.kt
+++ b/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/HiltComponentResolverTest.kt
@@ -100,6 +100,7 @@ class HiltComponentResolverTest {
         """.trimIndent())
 
         val result = compile(source)
+        result.assertOk()
 
         val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
         generated.assertContent("""
@@ -136,6 +137,7 @@ class HiltComponentResolverTest {
         """.trimIndent())
 
         val result = compile(source)
+        result.assertOk()
 
         val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
         generated.assertContent("""
@@ -172,6 +174,7 @@ class HiltComponentResolverTest {
         """.trimIndent())
 
         val result = compile(source)
+        result.assertOk()
 
         val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
         generated.assertContent("""
@@ -208,6 +211,7 @@ class HiltComponentResolverTest {
         """.trimIndent())
 
         val result = compile(source)
+        result.assertOk()
 
         val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
         generated.assertContent("""
@@ -244,6 +248,7 @@ class HiltComponentResolverTest {
         """.trimIndent())
 
         val result = compile(source)
+        result.assertOk()
 
         val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
         generated.assertContent("""
@@ -280,6 +285,7 @@ class HiltComponentResolverTest {
         """.trimIndent())
 
         val result = compile(source)
+        result.assertOk()
 
         val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
         generated.assertContent("""
@@ -351,6 +357,7 @@ class HiltComponentResolverTest {
         """.trimIndent())
 
         val result = compile(source)
+        result.assertOk()
 
         val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
         generated.assertContent("""
@@ -386,6 +393,7 @@ class HiltComponentResolverTest {
         """.trimIndent())
 
         val result = compile(source)
+        result.assertOk()
 
         val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
         generated.assertContent("""
@@ -421,6 +429,7 @@ class HiltComponentResolverTest {
         """.trimIndent())
 
         val result = compile(source)
+        result.assertOk()
 
         val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
         generated.assertContent("""
@@ -456,6 +465,7 @@ class HiltComponentResolverTest {
         """.trimIndent())
 
         val result = compile(source)
+        result.assertOk()
 
         val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
         generated.assertContent("""
@@ -491,6 +501,7 @@ class HiltComponentResolverTest {
         """.trimIndent())
 
         val result = compile(source)
+        result.assertOk()
 
         val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
         generated.assertContent("""
@@ -526,6 +537,7 @@ class HiltComponentResolverTest {
         """.trimIndent())
 
         val result = compile(source)
+        result.assertOk()
 
         val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
         generated.assertContent("""
@@ -561,6 +573,7 @@ class HiltComponentResolverTest {
         """.trimIndent())
 
         val result = compile(source)
+        result.assertOk()
 
         val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
         generated.assertContent("""

--- a/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/MetaAnnotationBindingTest.kt
+++ b/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/MetaAnnotationBindingTest.kt
@@ -1,0 +1,287 @@
+package com.uandcode.hilt.autobind.compiler
+
+import com.tschuchort.compiletesting.SourceFile
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertCompilationError
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertContent
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertHasGeneratedFile
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertOk
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.compile
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MetaAnnotationBindingTest {
+
+    @Test
+    fun `generates Binds module when class uses a meta-annotation alias for AutoBinds`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import javax.inject.Inject
+
+            @Target(AnnotationTarget.CLASS)
+            @AutoBinds
+            annotation class MyBind
+
+            interface UserRepository
+
+            @MyBind
+            class UserRepositoryImpl @Inject constructor() : UserRepository
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("UserRepositoryImplModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface UserRepositoryImplModule {
+              @Binds
+              public fun bindToUserRepository(`impl`: UserRepositoryImpl): UserRepository
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `meta-annotation forwards factory parameter`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import com.uandcode.hilt.autobind.factories.ClassBindingFactory
+            import javax.inject.Inject
+            import kotlin.reflect.KClass
+
+            interface BooksApi
+
+            class RetrofitFactory @Inject constructor() : ClassBindingFactory {
+                override fun <T : Any> create(kClass: KClass<T>): T { 
+                    throw UnsupportedOperationException() 
+                }
+            }
+
+            @Target(AnnotationTarget.CLASS)
+            @AutoBinds(factory = RetrofitFactory::class)
+            annotation class BindRetrofit
+
+            @BindRetrofit
+            interface BooksApiImpl : BooksApi
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("BooksApiImplModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object BooksApiImplModule {
+              @Provides
+              public fun provideBooksApiImpl(factory: RetrofitFactory): BooksApiImpl = factory.create(BooksApiImpl::class)
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `meta-annotation forwards installIn parameter`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import com.uandcode.hilt.autobind.HiltComponent
+            import javax.inject.Inject
+
+            interface Presenter
+
+            @Target(AnnotationTarget.CLASS)
+            @AutoBinds(installIn = HiltComponent.Activity)
+            annotation class BindToActivity
+
+            @BindToActivity
+            class MainPresenter @Inject constructor() : Presenter
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("MainPresenterModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.android.components.ActivityComponent
+
+            @Module
+            @InstallIn(ActivityComponent::class)
+            internal interface MainPresenterModule {
+              @Binds
+              public fun bindToPresenter(`impl`: MainPresenter): Presenter
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `multiple classes can use the same meta-annotation`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import javax.inject.Inject
+
+            @Target(AnnotationTarget.CLASS)
+            @AutoBinds
+            annotation class MyBind
+
+            interface RepoA
+            interface RepoB
+
+            @MyBind
+            class RepoAImpl @Inject constructor() : RepoA
+
+            @MyBind
+            class RepoBImpl @Inject constructor() : RepoB
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        result
+            .assertHasGeneratedFile("RepoAImplModule.kt")
+            .assertContent("""
+                package test
+
+                import dagger.Binds
+                import dagger.Module
+                import dagger.hilt.InstallIn
+                import dagger.hilt.components.SingletonComponent
+
+                @Module
+                @InstallIn(SingletonComponent::class)
+                internal interface RepoAImplModule {
+                  @Binds
+                  public fun bindToRepoA(`impl`: RepoAImpl): RepoA
+                }
+            """.trimIndent())
+
+        result
+            .assertHasGeneratedFile("RepoBImplModule.kt")
+            .assertContent("""
+                package test
+
+                import dagger.Binds
+                import dagger.Module
+                import dagger.hilt.InstallIn
+                import dagger.hilt.components.SingletonComponent
+
+                @Module
+                @InstallIn(SingletonComponent::class)
+                internal interface RepoBImplModule {
+                  @Binds
+                  public fun bindToRepoB(`impl`: RepoBImpl): RepoB
+                }
+            """.trimIndent())
+    }
+
+    @Test
+    fun `scope annotation on the annotated class is still respected`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import dagger.hilt.android.scopes.ActivityScoped
+            import javax.inject.Inject
+
+            @Target(AnnotationTarget.CLASS)
+            @AutoBinds
+            annotation class MyBind
+
+            interface Presenter
+
+            @MyBind
+            @ActivityScoped
+            class MainPresenter @Inject constructor() : Presenter
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("MainPresenterModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.android.components.ActivityComponent
+
+            @Module
+            @InstallIn(ActivityComponent::class)
+            internal interface MainPresenterModule {
+              @Binds
+              public fun bindToPresenter(`impl`: MainPresenter): Presenter
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `error when meta-annotation lacks @Target(AnnotationTarget CLASS)`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import javax.inject.Inject
+
+            @Target(AnnotationTarget.FUNCTION)
+            @AutoBinds
+            annotation class MyBind
+
+            interface Repo
+
+            @MyBind
+            class RepoImpl @Inject constructor() : Repo
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertCompilationError()
+        assertTrue(result.messages.contains("must declare @Target(AnnotationTarget.CLASS)"))
+    }
+
+    @Test
+    fun `meta-annotation with no @Target is not acceptable`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import javax.inject.Inject
+
+            @AutoBinds
+            annotation class MyBind
+
+            interface Repo
+
+            @MyBind
+            class RepoImpl @Inject constructor() : Repo
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertCompilationError()
+        assertTrue(result.messages.contains("must declare @Target(AnnotationTarget.CLASS)"))
+    }
+}

--- a/lib-compiler/src/test/kotlin/dagger/hilt/android/components/MockAndroidComponents.kt
+++ b/lib-compiler/src/test/kotlin/dagger/hilt/android/components/MockAndroidComponents.kt
@@ -1,0 +1,9 @@
+package dagger.hilt.android.components
+
+annotation class ActivityComponent
+annotation class ActivityRetainedComponent
+annotation class ViewModelComponent
+annotation class FragmentComponent
+annotation class ViewComponent
+annotation class ViewWithFragmentComponent
+annotation class ServiceComponent

--- a/lib-core/src/main/java/com/uandcode/hilt/autobind/AutoBinds.kt
+++ b/lib-core/src/main/java/com/uandcode/hilt/autobind/AutoBinds.kt
@@ -38,7 +38,7 @@ import kotlin.reflect.KClass
  *   the scope annotation on the class (falls back to [HiltComponent.Singleton] if unscoped).
  * @param factory optional [BindingFactory] to use for creating instances.
  */
-@Target(AnnotationTarget.CLASS)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.ANNOTATION_CLASS)
 @Retention(AnnotationRetention.SOURCE)
 public annotation class AutoBinds(
     val installIn: HiltComponent = HiltComponent.Unspecified,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
   - Class Factory: class-factory.md
   - Delegate Factory: delegate-factory.md
   - Multibinding: multibinding.md
+  - Annotation Aliases: annotation-aliases.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Users can now define custom annotation classes annotated with `@AutoBinds` (and optionally factory/installIn parameters) to create reusable binding aliases. Applying such an annotation to a class has the same effect as applying `@AutoBinds` directly with the same arguments.

The alias annotation must declare `@Target(AnnotationTarget.CLASS)`. The processor emits a compile-time error if this requirement is not met.