### PR TITLE
fix: Pin pymdown-extensions and pygments versions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install MkDocs
-        run: pip install mkdocs==1.6.1 mkdocs-material==9.7.6
+        run: pip install mkdocs==1.6.1 mkdocs-material==9.7.6 pymdown-extensions==10.21.2 pygments==2.20.0
 
       - name: Build documentation
         run: bash build-scripts/build-docs.sh


### PR DESCRIPTION
Version 10.21 has a bug where anchor_linenums causes filename=None to be passed to Pygments HtmlFormatter, crashing the mkdocs build. Version 10.21.2 fixes it. Also pin pygments==2.20.0 for consistency.