### PR TITLE
feat: Support scope annotations on @AutoBinds annotation aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Manual modules are not needed anymore, and Hilt can now inject `UserRepository` 
 | [Delegate factory](docs/delegate-factory.md)         | `@AutoBinds(factory = ...)`     | Provides a class and its sub-dependencies via `DelegateBindingFactory` (e.g., Room) |
 | [Multibinding](docs/multibinding.md)                 | `@AutoBindsIntoSet`             | Contributes to a Dagger `Set` multibinding                                          |
 | [Annotation aliases](docs/annotation-aliases.md)     | `@AutoBinds` as meta-annotation | Define custom annotations that act as short aliases for `@AutoBinds`                |
-| [Multi-Module Projects](docs/multi-module.md)        | —                               | Per-module setup in multi-module projects                                           |
+| [Multi-Module Projects](docs/multi-module.md)        | Aliases                         | Per-module setup in multi-module projects                                           |
 
 ## Requirements
 

--- a/docs/annotation-aliases.md
+++ b/docs/annotation-aliases.md
@@ -4,7 +4,7 @@
 
 - [Overview](#overview)
 - [Defining an alias](#defining-an-alias)
-- [Forwarding installIn](#forwarding-installin)
+- [Forwarding installIn and scope](#forwarding-installin-and-scope)
 - [Forwarding a factory](#forwarding-a-factory)
 - [Multiple classes with one alias](#multiple-classes-with-one-alias)
 - [Requirements for alias annotations](#requirements-for-alias-annotations)
@@ -54,42 +54,92 @@ annotation class MyBind
 The processor detects this declaration and treats every class annotated with
 `@MyBind` as if it were annotated with `@AutoBinds` directly.
 
-## Forwarding installIn
+## Forwarding installIn and scope
 
-The `installIn` component is fixed in the alias and automatically applied to
-every class that uses it:
+You can pin the `installIn` component in the alias, or let the processor
+auto-detect it from a scope annotation, or both:
 
 ```kotlin
+// explicit component only
 @Target(AnnotationTarget.CLASS)
 @AutoBinds(installIn = HiltComponent.Activity)
 annotation class BindToActivity
+
+// scope annotation only - component is auto-detected from @ActivityScoped
+@Target(AnnotationTarget.CLASS)
+@AutoBinds
+@ActivityScoped
+annotation class BindToActivity
+
+// both - scope annotation must be consistent with installIn
+@Target(AnnotationTarget.CLASS)
+@AutoBinds(installIn = HiltComponent.Activity)
+@ActivityScoped
+annotation class BindToActivity
 ```
 
+All three forms installs every class annotated with `@BindToActivity`
+into `ActivityComponent`. The last 2 examples also scope every class
+(`@ActivityScoped` annotation is added to the generated Hilt module).
+
+### Scope annotation on the alias
+
+Placing a scope annotation (e.g. `@Singleton`, `@ActivityScoped`) directly on
+the alias has two effects:
+
+1. **Component auto-detection** - if `installIn` is not set, the processor
+   infers the target component from the scope (same as with direct `@AutoBinds`).
+2. **Scoped factory bindings** - for `ClassBindingFactory` and
+   `DelegateBindingFactory`, the scope annotation is forwarded to the generated
+   `@Provides` function, making the binding scoped.
+
+For example, placing `@Singleton` on a `ClassBindingFactory` alias:
+
 ```kotlin
-@BindToActivity
-class MainPresenter @Inject constructor() : Presenter
-// same as: @AutoBinds(installIn = HiltComponent.Activity)
+@Target(AnnotationTarget.CLASS)
+@AutoBinds(factory = RetrofitBindingFactory::class)
+@Singleton
+annotation class BindRetrofit
 ```
 
-The annotated class can still carry a scope annotation. The processor validates
-that the scope is consistent with the `installIn` value, exactly as it does for
-direct `@AutoBinds` usage:
+Generates:
 
 ```kotlin
-// OK: @ActivityScoped is consistent with installIn = Activity
-@BindToActivity
+@Module
+@InstallIn(SingletonComponent::class)
+internal object UserApiModule {
+    @Provides
+    @Singleton
+    fun provideUserApi(factory: RetrofitBindingFactory): UserApi =
+        factory.create(UserApi::class)
+}
+```
+
+This is an alternative to placing `@AutoScoped` on the factory's `create()`
+method. Use the alias-level scope when you want different aliases to the same
+factory to have different scopes.
+
+### Scope conflicts
+
+The annotated class can still carry its own scope annotation. If it matches the
+alias scope it is redundant but accepted. If it conflicts, the processor emits a
+compile-time error:
+
+```kotlin
+@Target(AnnotationTarget.CLASS)
+@AutoBinds
+@Singleton
+annotation class MySingletonBind
+
+// ERROR: class is scoped to ActivityScoped but alias targets Singleton
+@MySingletonBind
 @ActivityScoped
 class MainPresenter @Inject constructor() : Presenter
-
-// ERROR: @Singleton does not match installIn = Activity
-@BindToActivity
-@Singleton
-class MainPresenter @Inject constructor() : Presenter
 ```
 
-If `installIn` is left at its default (`HiltComponent.Unspecified`), the
-processor auto-detects the component from the scope annotation on the annotated
-class, same as with direct `@AutoBinds`. See
+If `installIn` is left at its default (`HiltComponent.Unspecified`) and no
+scope annotation is present on either the alias or the annotated class, the
+processor defaults to `SingletonComponent`. See
 [Scopes and Components](scopes-and-components.md) for the full mapping.
 
 ## Forwarding a Factory
@@ -143,6 +193,10 @@ internal object UserApiModule {
 The alias works with all factory types: `ClassBindingFactory` (shown above) and
 `DelegateBindingFactory`. See [Class Factory](class-factory.md) and
 [Delegate Factory](delegate-factory.md) for details on each factory type.
+
+To make the factory binding scoped, you can either place `@AutoScoped` on the
+factory method, or place a scope annotation directly on the alias — see
+[Scope annotation on the alias](#scope-annotation-on-the-alias) above.
 
 ## Multiple Classes with One Alias
 

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/AnnotatedSymbolsResolver.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/AnnotatedSymbolsResolver.kt
@@ -203,13 +203,16 @@ internal class AnnotatedSymbolsResolver(
         val resolved = componentResolver.resolve(
             declaredComponent = annotation.installIn,
             annotatedClass = annotatedClass,
-            annotationName = AUTOBINDS_NAME,
+            annotationSource = annotationSource,
+            annotationName = originAnnotationName,
         ) ?: return
 
         val moduleInfo = ModuleInfo(
             annotatedClass = annotatedClass,
             hiltComponentClassName = resolved.hiltComponentClassName,
             scopeClassName = resolved.scopeClassName,
+            hasScopeAnnotation = resolved.hasScopeAnnotation,
+            isObjectModuleRequired = resolved.isObjectModuleRequired,
             annotationSource = annotationSource,
             annotationName = originAnnotationName,
         )
@@ -236,6 +239,7 @@ internal class AnnotatedSymbolsResolver(
         val resolved = componentResolver.resolve(
             declaredComponent = annotation.installIn,
             annotatedClass = annotatedClass,
+            annotationSource = annotatedClass,
             annotationName = AUTOBINDS_INTO_SET_NAME,
         ) ?: return
 
@@ -245,6 +249,8 @@ internal class AnnotatedSymbolsResolver(
             scopeClassName = resolved.scopeClassName,
             annotationSource = annotatedClass,
             moduleNameSuffix = "__IntoSetModule",
+            hasScopeAnnotation = resolved.hasScopeAnnotation,
+            isObjectModuleRequired = resolved.isObjectModuleRequired,
             annotationName = requireNotNull(AutoBindsIntoSet::class.simpleName)
         )
         onGenerateHiltModule.invoke(ModuleType.IntoSet, moduleInfo)

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/HiltComponentResolver.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/HiltComponentResolver.kt
@@ -21,6 +21,8 @@ internal class HiltComponentResolver(
     data class Result(
         val hiltComponentClassName: ClassName,
         val scopeClassName: ClassName,
+        val hasScopeAnnotation: Boolean,
+        val isObjectModuleRequired: Boolean,
     )
 
     /**
@@ -36,18 +38,33 @@ internal class HiltComponentResolver(
     fun resolve(
         declaredComponent: HiltComponent,
         annotatedClass: KSClassDeclaration,
+        annotationSource: KSClassDeclaration,
         annotationName: String,
     ): Result? {
-        val classScopeAnnotation = findScopeAnnotation(annotatedClass)
+        var classScopeAnnotation = findScopeAnnotation(annotatedClass)
+        var isObjectModuleRequired = false
+
+        if (annotationSource.qualifiedName?.asString() != annotatedClass.qualifiedName?.asString()) {
+            val annotationScopeAnnotation = findScopeAnnotation(annotationSource)
+            if (classScopeAnnotation == null && annotationScopeAnnotation != null) {
+                classScopeAnnotation = annotationScopeAnnotation
+                isObjectModuleRequired = true
+            } else if (classScopeAnnotation != annotationScopeAnnotation && annotationScopeAnnotation != null) {
+                return handleNonMatchingScopes(annotatedClass, classScopeAnnotation,
+                    annotationScopeAnnotation, annotationName)
+            }
+        }
 
         return if (declaredComponent == HiltComponent.Unspecified) {
-            resolveUnspecifiedComponent(classScopeAnnotation, annotatedClass, annotationName)
+            resolveUnspecifiedComponent(classScopeAnnotation, annotatedClass, annotationName, isObjectModuleRequired)
         } else if (classScopeAnnotation != null && classScopeAnnotation != declaredComponent.scopeClass) {
             handleNonMatchingExplicitComponents(declaredComponent, classScopeAnnotation, annotatedClass, annotationName)
         } else {
             Result(
                 hiltComponentClassName = ClassName.bestGuess(declaredComponent.componentClass),
                 scopeClassName = ClassName.bestGuess(declaredComponent.scopeClass),
+                hasScopeAnnotation = classScopeAnnotation != null,
+                isObjectModuleRequired = isObjectModuleRequired,
             )
         }
     }
@@ -56,6 +73,7 @@ internal class HiltComponentResolver(
         classScopeAnnotation: String?,
         annotatedClass: KSClassDeclaration,
         annotationName: String,
+        isObjectModuleRequired: Boolean,
     ): Result? {
         val resolved = if (classScopeAnnotation != null) {
             resolveFromScope(classScopeAnnotation, annotatedClass, annotationName) ?: return null
@@ -65,6 +83,8 @@ internal class HiltComponentResolver(
         return Result(
             hiltComponentClassName = ClassName.bestGuess(resolved.componentClass),
             scopeClassName = ClassName.bestGuess(resolved.scopeClass),
+            hasScopeAnnotation = classScopeAnnotation != null,
+            isObjectModuleRequired = isObjectModuleRequired,
         )
     }
 
@@ -80,9 +100,23 @@ internal class HiltComponentResolver(
         logger.error(
             "@$annotationName: class '${annotatedClass.simpleName.asString()}' is scoped " +
                     "with @$scopeSimpleName but installIn targets " +
-                    "${declaredComponent.name} (expected @$expectedScopeSimpleName)",
+                    "${declaredComponent.name} (expected scope is @$expectedScopeSimpleName)",
             annotatedClass,
         )
+        return null
+    }
+
+    private fun handleNonMatchingScopes(
+        annotatedClass: KSClassDeclaration,
+        classScopeAnnotation: String?,
+        annotationSourceScopeAnnotation: String?,
+        annotationName: String,
+    ): Result? {
+        val classScope = classScopeAnnotation ?: "(Undefined)"
+        val sourceScope = annotationSourceScopeAnnotation ?: "(Undefined)"
+        logger.error("@$annotationName: class '${annotatedClass.simpleName.asString()}' has " +
+                "different scopes. The class is scoped to '$classScope', but the annotation " +
+                "@$annotationName targets '$sourceScope'.", annotatedClass)
         return null
     }
 

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/ModuleInfo.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/ModuleInfo.kt
@@ -7,13 +7,15 @@ import com.squareup.kotlinpoet.ksp.toClassName
 /**
  * Holds naming information for the generated Hilt module.
  */
-internal class ModuleInfo(
+internal data class ModuleInfo(
     val annotatedClass: KSClassDeclaration,
     val hiltComponentClassName: ClassName,
     val scopeClassName: ClassName,
+    val hasScopeAnnotation: Boolean,
+    val isObjectModuleRequired: Boolean,
     val annotationName: String,
     val annotationSource: KSClassDeclaration,
-    moduleNameSuffix: String = "Module",
+    val moduleNameSuffix: String = "Module",
 ) {
     val originClassName: ClassName = annotatedClass.toClassName()
     val transformedClassName: String = originClassName.simpleNames.joinToString("__")

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/ClassFactoryModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/ClassFactoryModuleGenerator.kt
@@ -45,8 +45,8 @@ internal class ClassFactoryModuleGenerator(
         val createMethod = factoryDeclaration.getDeclaredFunctions()
             .firstOrNull { it.simpleName.asString() == CREATE_METHOD &&
                     it.parameters.singleOrNull()?.isKClassType() == true }
-        val isAutoScoped = createMethod
-            ?.isAnnotationPresent(AutoScoped::class) == true
+        val isAutoScoped = createMethod?.isAnnotationPresent(AutoScoped::class) == true
+                || moduleInfo.hasScopeAnnotation
 
         return TypeSpec.objectBuilder(moduleClassName)
             .applyHiltModuleAnnotationsAndModifiers(hiltComponentClassName)

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/DefaultModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/DefaultModuleGenerator.kt
@@ -15,6 +15,7 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeSpec
 import com.uandcode.hilt.autobind.compiler.ModuleInfo
 import dagger.Binds
+import dagger.Provides
 import javax.inject.Inject
 
 /**
@@ -55,11 +56,20 @@ internal class DefaultModuleGenerator(
             return null
         }
 
-        return TypeSpec
-            .interfaceBuilder(className = moduleClassName)
+        val typeSpecHeader = if (isObjectModuleRequired) {
+            TypeSpec.objectBuilder(className = moduleClassName)
+        } else {
+            TypeSpec.interfaceBuilder(className = moduleClassName)
+        }
+
+        return typeSpecHeader
             .applyHiltModuleAnnotationsAndModifiers(hiltComponentClassName)
             .apply {
-                addBindFunctions(moduleInfo, originClassName, targetInterfaces)
+                if (isObjectModuleRequired) {
+                    addProvideFunctions(moduleInfo, originClassName, targetInterfaces)
+                } else {
+                    addBindFunctions(moduleInfo, originClassName, targetInterfaces)
+                }
             }
             .build()
     }
@@ -73,6 +83,25 @@ internal class DefaultModuleGenerator(
             .addParameter(name = "impl", type = originClassName)
             .addAnnotation(Binds::class)
             .addModifiers(KModifier.ABSTRACT)
+            .returns(it.interfaceTypeName)
+            .build()
+        addFunction(funSpec)
+    }
+
+    private fun TypeSpec.Builder.addProvideFunctions(
+        moduleInfo: ModuleInfo,
+        originClassName: ClassName,
+        targetInterfaces: List<KSType>,
+    ) = forEachTargetInterface(moduleInfo, targetInterfaces) {
+        val funSpec = FunSpec.builder(it.functionName)
+            .addParameter(name = "impl", type = originClassName)
+            .addAnnotation(Provides::class)
+            .apply {
+                if (moduleInfo.hasScopeAnnotation && moduleInfo.isObjectModuleRequired) {
+                    addAnnotation(moduleInfo.scopeClassName)
+                }
+            }
+            .addCode("return impl")
             .returns(it.interfaceTypeName)
             .build()
         addFunction(funSpec)

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/DelegateFactoryModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/DelegateFactoryModuleGenerator.kt
@@ -49,7 +49,8 @@ internal class DelegateFactoryModuleGenerator(
                 it.simpleName.asString() == PROVIDE_DELEGATE_METHOD && it.modifiers.contains(Modifier.OVERRIDE)
             }
         val isAutoScoped = provideDelegateMethod
-            ?.isAnnotationPresent(AutoScoped::class) == true
+            ?.isAnnotationPresent(AutoScoped::class) == true ||
+                moduleInfo.hasScopeAnnotation
 
         val delegateMethods = annotatedClass.getDeclaredFunctions()
             .filter { !it.isConstructor() }

--- a/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/DelegateFactoryBindingTest.kt
+++ b/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/DelegateFactoryBindingTest.kt
@@ -2,6 +2,7 @@ package com.uandcode.hilt.autobind.compiler
 
 import com.tschuchort.compiletesting.SourceFile
 import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertCompilationError
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertContent
 import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertHasGeneratedFile
 import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertOk
 import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.compile
@@ -39,13 +40,27 @@ class DelegateFactoryBindingTest {
         result.assertOk()
 
         val generated = result.assertHasGeneratedFile("MyDbModule.kt")
-        assertTrue(generated.contains("fun provideMyDb"))
-        assertTrue(generated.contains("factory.provideDelegate()"))
-        assertTrue(generated.contains("fun provideNoteDao"))
-        assertTrue(generated.contains("delegate.noteDao()"))
-        assertTrue(generated.contains("fun provideOrderDao"))
-        assertTrue(generated.contains("delegate.orderDao()"))
-        assertTrue(generated.contains("internal object MyDbModule"))
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object MyDbModule {
+              @Provides
+              public fun provideMyDb(factory: MyDbFactory): MyDb = factory.provideDelegate()
+
+              @Provides
+              public fun provideNoteDao(`delegate`: MyDb): NoteDao = delegate.noteDao()
+
+              @Provides
+              public fun provideOrderDao(`delegate`: MyDb): OrderDao = delegate.orderDao()
+            }
+        """.trimIndent())
     }
 
     @Test
@@ -75,8 +90,24 @@ class DelegateFactoryBindingTest {
         result.assertOk()
 
         val generated = result.assertHasGeneratedFile("MyDbModule.kt")
-        assertTrue(generated.contains("fun provideNoteDao"))
-        assertTrue(generated.contains("delegate.noteDao()"))
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object MyDbModule {
+              @Provides
+              public fun provideMyDb(factory: MyDbFactory): MyDb = factory.provideDelegate()
+
+              @Provides
+              public fun provideNoteDao(`delegate`: MyDb): NoteDao = delegate.noteDao()
+            }
+        """.trimIndent())
     }
 
     @Test
@@ -108,11 +139,26 @@ class DelegateFactoryBindingTest {
         result.assertOk()
 
         val generated = result.assertHasGeneratedFile("MyDbModule.kt")
-        // The main provide method should have @Singleton
-        assertTrue(generated.contains("@Singleton"))
-        // Count occurrences: @Singleton should appear only once (for provideMyDb, not provideNoteDao)
-        val singletonCount = Regex("@Singleton").findAll(generated).count()
-        assertTrue(singletonCount == 1, "Expected @Singleton once but found $singletonCount times")
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import javax.inject.Singleton
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object MyDbModule {
+              @Provides
+              @Singleton
+              public fun provideMyDb(factory: MyDbFactory): MyDb = factory.provideDelegate()
+
+              @Provides
+              public fun provideNoteDao(`delegate`: MyDb): NoteDao = delegate.noteDao()
+            }
+        """.trimIndent())
     }
 
     @Test

--- a/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/IntoSetBindingTest.kt
+++ b/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/IntoSetBindingTest.kt
@@ -2,6 +2,7 @@ package com.uandcode.hilt.autobind.compiler
 
 import com.tschuchort.compiletesting.SourceFile
 import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertCompilationError
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertContent
 import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertHasGeneratedFile
 import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertOk
 import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.compile
@@ -28,10 +29,23 @@ class IntoSetBindingTest {
         result.assertOk()
 
         val generated = result.assertHasGeneratedFile("LoggingInterceptor__IntoSetModule.kt")
-        assertTrue(generated.contains("@Binds"))
-        assertTrue(generated.contains("@IntoSet"))
-        assertTrue(generated.contains("fun bindToInterceptor"))
-        assertTrue(generated.contains("SingletonComponent::class"))
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import dagger.multibindings.IntoSet
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface LoggingInterceptor__IntoSetModule {
+              @Binds
+              @IntoSet
+              public fun bindToInterceptor(`impl`: LoggingInterceptor): Interceptor
+            }
+        """.trimIndent())
     }
 
     @Test
@@ -54,11 +68,40 @@ class IntoSetBindingTest {
         result.assertOk()
 
         val bindsModule = result.assertHasGeneratedFile("DefaultInterceptorModule.kt")
-        assertTrue(bindsModule.contains("@Binds"))
+        bindsModule.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface DefaultInterceptorModule {
+              @Binds
+              public fun bindToInterceptor(`impl`: DefaultInterceptor): Interceptor
+            }
+        """.trimIndent())
 
         val intoSetModule = result.assertHasGeneratedFile("DefaultInterceptor__IntoSetModule.kt")
-        assertTrue(intoSetModule.contains("@Binds"))
-        assertTrue(intoSetModule.contains("@IntoSet"))
+        intoSetModule.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import dagger.multibindings.IntoSet
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface DefaultInterceptor__IntoSetModule {
+              @Binds
+              @IntoSet
+              public fun bindToInterceptor(`impl`: DefaultInterceptor): Interceptor
+            }
+        """.trimIndent())
     }
 
     @Test
@@ -116,6 +159,22 @@ class IntoSetBindingTest {
         result.assertOk()
 
         val generated = result.assertHasGeneratedFile("ScopedInterceptor__IntoSetModule.kt")
-        assertTrue(generated.contains("SingletonComponent::class"))
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import dagger.multibindings.IntoSet
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface ScopedInterceptor__IntoSetModule {
+              @Binds
+              @IntoSet
+              public fun bindToInterceptor(`impl`: ScopedInterceptor): Interceptor
+            }
+        """.trimIndent())
     }
 }

--- a/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/MetaAnnotationBindingTest.kt
+++ b/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/MetaAnnotationBindingTest.kt
@@ -284,4 +284,209 @@ class MetaAnnotationBindingTest {
         result.assertCompilationError()
         assertTrue(result.messages.contains("must declare @Target(AnnotationTarget.CLASS)"))
     }
+
+    @Test
+    fun `error when scope annotation on meta-annotation does not match installIn component`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import com.uandcode.hilt.autobind.HiltComponent
+            import dagger.hilt.android.scopes.ActivityScoped
+            import javax.inject.Inject
+
+            interface Presenter
+
+            @Target(AnnotationTarget.CLASS)
+            @AutoBinds(installIn = HiltComponent.Fragment)
+            @ActivityScoped
+            annotation class BindToActivity
+
+            @BindToActivity
+            class MainPresenter @Inject constructor() : Presenter
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertCompilationError()
+
+        assertTrue(result.messages.contains("class 'MainPresenter' is scoped with " +
+                "@ActivityScoped but installIn targets Fragment (expected scope " +
+                "is @FragmentScoped)"))
+    }
+
+    @Test
+    fun `scope annotation on meta-annotation auto-detects component for Binds module`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import dagger.hilt.android.scopes.ActivityScoped
+            import javax.inject.Inject
+
+            interface Presenter
+
+            @Target(AnnotationTarget.CLASS)
+            @AutoBinds
+            @ActivityScoped
+            annotation class BindToActivity
+
+            @BindToActivity
+            class MainPresenter @Inject constructor() : Presenter
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("MainPresenterModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.android.components.ActivityComponent
+            import dagger.hilt.android.scopes.ActivityScoped
+            
+            @Module
+            @InstallIn(ActivityComponent::class)
+            internal object MainPresenterModule {
+              @Provides
+              @ActivityScoped
+              public fun bindToPresenter(`impl`: MainPresenter): Presenter = impl
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `scope annotation on meta-annotation generates scoped Provides with ClassFactory`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import com.uandcode.hilt.autobind.factories.ClassBindingFactory
+            import javax.inject.Inject
+            import javax.inject.Singleton
+            import kotlin.reflect.KClass
+
+            interface BooksApi
+
+            class RetrofitFactory @Inject constructor() : ClassBindingFactory {
+                override fun <T : Any> create(kClass: KClass<T>): T {
+                    throw UnsupportedOperationException()
+                }
+            }
+
+            @Target(AnnotationTarget.CLASS)
+            @AutoBinds(factory = RetrofitFactory::class)
+            @Singleton
+            annotation class BindRetrofit
+
+            @BindRetrofit
+            interface BooksApiImpl : BooksApi
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("BooksApiImplModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import javax.inject.Singleton
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object BooksApiImplModule {
+              @Provides
+              @Singleton
+              public fun provideBooksApiImpl(factory: RetrofitFactory): BooksApiImpl = factory.create(BooksApiImpl::class)
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `scope annotation on meta-annotation generates scoped Provides with DelegateFactory`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import com.uandcode.hilt.autobind.factories.DelegateBindingFactory
+            import javax.inject.Inject
+            import javax.inject.Singleton
+
+            interface NoteDao
+
+            class MyDbFactory @Inject constructor() : DelegateBindingFactory<MyDb> {
+                override fun provideDelegate(): MyDb {
+                    throw UnsupportedOperationException()
+                }
+            }
+
+            @Target(AnnotationTarget.CLASS)
+            @AutoBinds(factory = MyDbFactory::class)
+            @Singleton
+            annotation class BindDb
+
+            @BindDb
+            abstract class MyDb {
+                abstract fun noteDao(): NoteDao
+            }
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("MyDbModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import javax.inject.Singleton
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object MyDbModule {
+              @Provides
+              @Singleton
+              public fun provideMyDb(factory: MyDbFactory): MyDb = factory.provideDelegate()
+
+              @Provides
+              public fun provideNoteDao(`delegate`: MyDb): NoteDao = delegate.noteDao()
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `error when class scope conflicts with meta-annotation scope`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import dagger.hilt.android.scopes.ActivityScoped
+            import javax.inject.Inject
+            import javax.inject.Singleton
+
+            interface Presenter
+
+            @Target(AnnotationTarget.CLASS)
+            @AutoBinds
+            @Singleton
+            annotation class MySingletonBind
+
+            @MySingletonBind
+            @ActivityScoped
+            class MainPresenter @Inject constructor() : Presenter
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertCompilationError()
+        assertTrue(result.messages.contains("different scopes"))
+    }
 }


### PR DESCRIPTION
Scope annotations (e.g. Singleton, ActivityScoped) can now be placed directly on an alias annotation. For Binds modules, the scope is used to auto-detect the target Hilt component and scope all bindings (effectively, they are converted to Provides bindings). For factory-based bindings (ClassBindingFactory, DelegateBindingFactory), the scope is forwarded to the generated Provides function - as an alternative to AutoScoped on the factory method. A compile-time error is emitted when the alias scope conflicts with a scope annotation on the annotated class.