### PR TITLE
feat: Support binding to direct parent classes in addition to interfaces

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -5,6 +5,7 @@
 - [Single interface binding](#single-interface-binding)
 - [Multiple interfaces](#multiple-interfaces)
 - [Generic interfaces](#generic-interfaces)
+- [Parent class binding](#parent-class-binding)
 - [How it works](#how-it-works)
 - [Requirements for annotated classes](#requirements-for-annotated-classes)
 
@@ -97,14 +98,53 @@ internal interface StringRepositoryModule {
 }
 ```
 
+## Parent Class Binding
+
+`@AutoBinds` also works when a class extends an `open` or `abstract` parent
+class directly. A binding is generated for the parent class in the same way as
+for interfaces:
+
+```kotlin
+abstract class BaseService
+
+@AutoBinds
+class HomeService @Inject constructor() : BaseService()
+```
+
+**Generated code:**
+
+```kotlin
+@Module
+@InstallIn(SingletonComponent::class)
+internal interface HomeServiceModule {
+    @Binds
+    fun bindToBaseService(impl: HomeService): BaseService
+}
+```
+
+A class can mix parent class and interface supertypes - a binding is generated
+for each direct supertype (excluding `Any`):
+
+```kotlin
+abstract class BaseService
+interface Trackable
+
+@AutoBinds
+class HomeService @Inject constructor() : BaseService(), Trackable
+```
+
+This generates a single module with `@Binds` functions for both `BaseService`
+and `Trackable`.
+
 ## How It Works
 
 Hilt AutoBind is a [KSP](https://github.com/google/ksp) annotation processor
 that runs at compile time. For each class annotated with `@AutoBinds`, it:
 
-1. Finds all directly implemented interfaces.
+1. Finds all direct supertypes (implemented interfaces and extended parent
+   classes, excluding `Any`).
 2. Generates an `internal interface` Hilt module with a `@Binds` function for
-   each interface.
+   each supertype.
 3. Installs the module in the appropriate Hilt component (see
    [Scopes and Components](scopes-and-components.md)).
 
@@ -119,6 +159,6 @@ A class annotated with `@AutoBinds` (in default mode, without a `factory`) must:
 - Be **non-abstract** (no `abstract` modifier).
 - **Not be an inner class** (no `inner` modifier).
 - Have a **primary constructor annotated with `@Inject`**.
-- Implement **at least one interface**.
+- Implement **at least one interface** or extend a **non-`Any` parent class**.
 
 The processor emits a compile-time error if any of these conditions are not met.

--- a/docs/multibinding.md
+++ b/docs/multibinding.md
@@ -11,8 +11,9 @@
 ## Overview
 
 Use `@AutoBindsIntoSet` to contribute a class into a Dagger multibinding `Set`
-of each directly implemented interface. This lets you collect multiple
-implementations automatically without maintaining a manual module.
+of each direct supertype (implemented interfaces and extended parent classes).
+This lets you collect multiple implementations automatically without maintaining
+a manual module.
 
 ## Contributing to a Set
 
@@ -87,4 +88,4 @@ internal interface LoggingInterceptor__IntoSetModule {
 
 The same class requirements as [basic usage](basic-usage.md#requirements-for-annotated-classes)
 apply: the class must be concrete, non-abstract, not an inner class, have `@Inject` on its
-primary constructor, and implement at least one interface.
+primary constructor, and implement at least one interface or extend a parent class.

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/AbstractModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/AbstractModuleGenerator.kt
@@ -20,14 +20,14 @@ internal abstract class AbstractModuleGenerator(
         )
     }
 
-    protected fun forEachTargetInterface(
+    protected fun forEachTargetSuperType(
         moduleInfo: ModuleInfo,
-        targetInterfaces: List<KSType>,
-        block: (TargetInterface) -> Unit,
+        targetSuperTypes: List<KSType>,
+        block: (TargetSuperType) -> Unit,
     ) = with(moduleInfo) {
-        val classNames = targetInterfaces.mapNotNull { (it.declaration as? KSClassDeclaration)?.toClassName() }
+        val classNames = targetSuperTypes.mapNotNull { (it.declaration as? KSClassDeclaration)?.toClassName() }
         if (classNames.isEmpty()) {
-            logNoImplementedInterfaces(annotatedClass)
+            logNoImplementedSuperTypes(annotatedClass)
             return
         }
         val duplicateSimpleNames = classNames
@@ -35,24 +35,24 @@ internal abstract class AbstractModuleGenerator(
             .filterValues { it.size > 1 }
             .keys
 
-        for ((index, targetInterface) in targetInterfaces.withIndex()) {
-            val interfaceClassName = classNames[index]
-            val interfaceTypeName = targetInterface.toTypeName()
-            val functionName = if (interfaceClassName.simpleName in duplicateSimpleNames) {
-                "bindTo${interfaceClassName.simpleName}_${interfaceClassName.packageName.replace('.', '_')}"
+        for ((index, targetSuperType) in targetSuperTypes.withIndex()) {
+            val supertypeClassName = classNames[index]
+            val supertypeTypeName = targetSuperType.toTypeName()
+            val functionName = if (supertypeClassName.simpleName in duplicateSimpleNames) {
+                "bindTo${supertypeClassName.simpleName}_${supertypeClassName.packageName.replace('.', '_')}"
             } else {
-                "bindTo${interfaceClassName.simpleName}"
+                "bindTo${supertypeClassName.simpleName}"
             }
-            block(TargetInterface(functionName, interfaceTypeName))
+            block(TargetSuperType(functionName, supertypeTypeName))
         }
     }
 
-    protected fun ModuleInfo.logNoImplementedInterfaces(annotatedClass: KSClassDeclaration) {
-        logError("must implement at least one interface", annotatedClass)
+    protected fun ModuleInfo.logNoImplementedSuperTypes(annotatedClass: KSClassDeclaration) {
+        logError("must implement at least one interface or extend a super-class", annotatedClass)
     }
 
-    class TargetInterface(
+    class TargetSuperType(
         val functionName: String,
-        val interfaceTypeName: TypeName,
+        val supertypeTypeName: TypeName,
     )
 }

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/DefaultModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/DefaultModuleGenerator.kt
@@ -37,9 +37,9 @@ internal class DefaultModuleGenerator(
             return null
         }
 
-        val targetInterfaces = annotatedClass.getTargetInterfaces()
-        if (targetInterfaces.isEmpty()) {
-            logNoImplementedInterfaces(annotatedClass)
+        val targetSuperTypes = annotatedClass.getTargetSuperTypes()
+        if (targetSuperTypes.isEmpty()) {
+            logNoImplementedSuperTypes(annotatedClass)
             return null
         }
 
@@ -66,9 +66,9 @@ internal class DefaultModuleGenerator(
             .applyHiltModuleAnnotationsAndModifiers(hiltComponentClassName)
             .apply {
                 if (isObjectModuleRequired) {
-                    addProvideFunctions(moduleInfo, originClassName, targetInterfaces)
+                    addProvideFunctions(moduleInfo, originClassName, targetSuperTypes)
                 } else {
-                    addBindFunctions(moduleInfo, originClassName, targetInterfaces)
+                    addBindFunctions(moduleInfo, originClassName, targetSuperTypes)
                 }
             }
             .build()
@@ -77,13 +77,13 @@ internal class DefaultModuleGenerator(
     private fun TypeSpec.Builder.addBindFunctions(
         moduleInfo: ModuleInfo,
         originClassName: ClassName,
-        targetInterfaces: List<KSType>,
-    ) = forEachTargetInterface(moduleInfo, targetInterfaces) {
+        targetSuperTypes: List<KSType>,
+    ) = forEachTargetSuperType(moduleInfo, targetSuperTypes) {
         val funSpec = FunSpec.builder(it.functionName)
             .addParameter(name = "impl", type = originClassName)
             .addAnnotation(Binds::class)
             .addModifiers(KModifier.ABSTRACT)
-            .returns(it.interfaceTypeName)
+            .returns(it.supertypeTypeName)
             .build()
         addFunction(funSpec)
     }
@@ -91,8 +91,8 @@ internal class DefaultModuleGenerator(
     private fun TypeSpec.Builder.addProvideFunctions(
         moduleInfo: ModuleInfo,
         originClassName: ClassName,
-        targetInterfaces: List<KSType>,
-    ) = forEachTargetInterface(moduleInfo, targetInterfaces) {
+        targetSuperTypes: List<KSType>,
+    ) = forEachTargetSuperType(moduleInfo, targetSuperTypes) {
         val funSpec = FunSpec.builder(it.functionName)
             .addParameter(name = "impl", type = originClassName)
             .addAnnotation(Provides::class)
@@ -102,7 +102,7 @@ internal class DefaultModuleGenerator(
                 }
             }
             .addCode("return impl")
-            .returns(it.interfaceTypeName)
+            .returns(it.supertypeTypeName)
             .build()
         addFunction(funSpec)
     }

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/IntoSetModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/IntoSetModuleGenerator.kt
@@ -39,9 +39,9 @@ internal class IntoSetModuleGenerator(
             return null
         }
 
-        val targetInterfaces = annotatedClass.getTargetInterfaces()
-        if (targetInterfaces.isEmpty()) {
-            logError("must implement at least one interface", annotatedClass)
+        val targetSuperTypes = annotatedClass.getTargetSuperTypes()
+        if (targetSuperTypes.isEmpty()) {
+            logNoImplementedSuperTypes(annotatedClass)
             return null
         }
 
@@ -62,7 +62,7 @@ internal class IntoSetModuleGenerator(
             .interfaceBuilder(className = moduleClassName)
             .applyHiltModuleAnnotationsAndModifiers(hiltComponentClassName)
             .apply {
-                addBindIntoSetFunctions(moduleInfo, originClassName, targetInterfaces)
+                addBindIntoSetFunctions(moduleInfo, originClassName, targetSuperTypes)
             }
             .build()
     }
@@ -70,14 +70,14 @@ internal class IntoSetModuleGenerator(
     private fun TypeSpec.Builder.addBindIntoSetFunctions(
         moduleInfo: ModuleInfo,
         originClassName: ClassName,
-        targetInterfaces: List<KSType>,
-    ) = forEachTargetInterface(moduleInfo, targetInterfaces) {
+        targetSuperTypes: List<KSType>,
+    ) = forEachTargetSuperType(moduleInfo, targetSuperTypes) {
         val funSpec = FunSpec.builder(it.functionName)
             .addParameter(name = "impl", type = originClassName)
             .addAnnotation(Binds::class)
             .addAnnotation(IntoSet::class)
             .addModifiers(KModifier.ABSTRACT)
-            .returns(it.interfaceTypeName)
+            .returns(it.supertypeTypeName)
             .build()
         addFunction(funSpec)
     }

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/KspClassDeclarationExtensions.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/KspClassDeclarationExtensions.kt
@@ -4,9 +4,16 @@ import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 
-internal fun KSClassDeclaration.getTargetInterfaces(): List<KSType> {
+internal fun KSClassDeclaration.getTargetSuperTypes(): List<KSType> {
     return superTypes
         .map { it.resolve() }
-        .filter { (it.declaration as? KSClassDeclaration)?.classKind == ClassKind.INTERFACE }
+        .filter { type ->
+            val declaration = type.declaration as? KSClassDeclaration ?: return@filter false
+            when (declaration.classKind) {
+                ClassKind.INTERFACE -> true
+                ClassKind.CLASS -> declaration.qualifiedName?.asString() != "kotlin.Any"
+                else -> false
+            }
+        }
         .toList()
 }

--- a/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/DefaultBindingTest.kt
+++ b/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/DefaultBindingTest.kt
@@ -100,7 +100,8 @@ class DefaultBindingTest {
 
         val result = compile(source)
         result.assertCompilationError()
-        assertTrue(result.messages.contains("must implement at least one interface"))
+        assertTrue(result.messages.contains("must implement at least one interface " +
+                "or extend a super-class"))
     }
 
     @Test
@@ -286,6 +287,115 @@ class DefaultBindingTest {
 
               @Binds
               public fun bindToCloseable_java_io(`impl`: MyImpl): java.io.Closeable
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `binds direct parent classes`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import javax.inject.Inject
+
+            open class ParentClass
+
+            @AutoBinds
+            class ChildClass @Inject constructor() : ParentClass()
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("ChildClassModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface ChildClassModule {
+              @Binds
+              public fun bindToParentClass(`impl`: ChildClass): ParentClass
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `binds mixed direct parent class and interfaces`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import javax.inject.Inject
+
+            open class ParentClass
+            interface Interface
+
+            @AutoBinds
+            class ChildClass @Inject constructor() : ParentClass(), Interface
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("ChildClassModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface ChildClassModule {
+              @Binds
+              public fun bindToParentClass(`impl`: ChildClass): ParentClass
+              @Binds
+              public fun bindToInterface(`impl`: ChildClass): Interface
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `no bindings for grand-parents`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import javax.inject.Inject
+
+            open class GrandParentClass
+            open class ParentClass : GrandParentClass()
+
+            @AutoBinds
+            class ChildClass @Inject constructor() : ParentClass()
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("ChildClassModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface ChildClassModule {
+              @Binds
+              public fun bindToParentClass(`impl`: ChildClass): ParentClass
             }
         """.trimIndent())
     }

--- a/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/IntoSetBindingTest.kt
+++ b/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/IntoSetBindingTest.kt
@@ -137,7 +137,7 @@ class IntoSetBindingTest {
 
         val result = compile(source)
         result.assertCompilationError()
-        assertTrue(result.messages.contains("must implement at least one interface"))
+        assertTrue(result.messages.contains("must implement at least one interface or extend a super-class"))
     }
 
     @Test
@@ -174,6 +174,123 @@ class IntoSetBindingTest {
               @Binds
               @IntoSet
               public fun bindToInterceptor(`impl`: ScopedInterceptor): Interceptor
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `binds direct parent classes`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBindsIntoSet
+            import javax.inject.Inject
+
+            open class ParentClass
+
+            @AutoBindsIntoSet
+            class ChildClass @Inject constructor() : ParentClass()
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("ChildClass__IntoSetModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import dagger.multibindings.IntoSet
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface ChildClass__IntoSetModule {
+              @Binds
+              @IntoSet
+              public fun bindToParentClass(`impl`: ChildClass): ParentClass
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `binds mixed direct parent class and interfaces`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBindsIntoSet
+            import javax.inject.Inject
+
+            open class ParentClass
+            interface Interface
+
+            @AutoBindsIntoSet
+            class ChildClass @Inject constructor() : ParentClass(), Interface
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("ChildClass__IntoSetModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import dagger.multibindings.IntoSet
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface ChildClass__IntoSetModule {
+              @Binds
+              @IntoSet
+              public fun bindToParentClass(`impl`: ChildClass): ParentClass
+              
+              @Binds
+              @IntoSet
+              public fun bindToInterface(`impl`: ChildClass): Interface
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `no bindings for grand-parents`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBindsIntoSet
+            import javax.inject.Inject
+
+            open class GrandParentClass
+            open class ParentClass : GrandParentClass()
+
+            @AutoBindsIntoSet
+            class ChildClass @Inject constructor() : ParentClass()
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("ChildClass__IntoSetModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import dagger.multibindings.IntoSet
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface ChildClass__IntoSetModule {
+              @Binds
+              @IntoSet
+              public fun bindToParentClass(`impl`: ChildClass): ParentClass
             }
         """.trimIndent())
     }


### PR DESCRIPTION
Extend `@AutoBinds` and `@AutoBindsIntoSet` to generate Hilt `@Binds` modules for directly extended parent classes, not only implemented interfaces. The 'kotlin.Any; is excluded from the candidates.