### PR TITLE
feat: Add bindTo parameter to @AutoBinds and @AutoBindsIntoSet

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -6,6 +6,7 @@
 - [Multiple interfaces](#multiple-interfaces)
 - [Generic interfaces](#generic-interfaces)
 - [Parent class binding](#parent-class-binding)
+- [Selecting specific binding targets](#selecting-specific-binding-targets)
 - [How it works](#how-it-works)
 - [Requirements for annotated classes](#requirements-for-annotated-classes)
 
@@ -135,6 +136,37 @@ class HomeService @Inject constructor() : BaseService(), Trackable
 
 This generates a single module with `@Binds` functions for both `BaseService`
 and `Trackable`.
+
+## Selecting Specific Binding Targets
+
+By default, `@AutoBinds` generates a binding for every direct supertype. Use
+`bindTo` to restrict which supertypes are included, or to target a
+grandparent class that is not a direct supertype:
+
+```kotlin
+interface Repo
+interface Closeable
+interface Auditable
+
+// Only binds to Repo; Closeable and Auditable are excluded
+@AutoBinds(bindTo = [Repo::class])
+class RepoImpl @Inject constructor() : Repo, Closeable, Auditable
+```
+
+```kotlin
+interface GrandParent
+open class Parent : GrandParent
+
+// Binds to GrandParent even though it's not a direct supertype
+@AutoBinds(bindTo = [GrandParent::class])
+class Child @Inject constructor() : Parent()
+```
+
+`bindTo` accepts any transitive supertype of the annotated class. The
+processor emits a compile-time error if a listed type is not a supertype
+at all.
+
+When `bindTo` is empty (the default), all direct supertypes are used.
 
 ## How It Works
 

--- a/docs/multibinding.md
+++ b/docs/multibinding.md
@@ -6,6 +6,7 @@
 - [Contributing to a Set](#contributing-to-a-set)
 - [Combining with @AutoBinds](#combining-with-autobinds)
 - [Choosing a component](#choosing-a-component)
+- [Selecting specific binding targets](#selecting-specific-binding-targets)
 - [Generated code](#generated-code)
 
 ## Overview
@@ -71,6 +72,24 @@ class ViewModelInterceptor @Inject constructor() : Interceptor { /* ... */ }
 ```
 
 See [Scopes and Components](scopes-and-components.md) for the full reference.
+
+## Selecting Specific Binding Targets
+
+By default, `@AutoBindsIntoSet` contributes the class to a `Set` of every
+direct supertype. Use `bindTo` to restrict which supertypes are included or to
+target a grandparent:
+
+```kotlin
+interface BaseHandler
+open class AbstractHandler : BaseHandler
+
+// Contributes to Set<BaseHandler> only, skipping AbstractHandler
+@AutoBindsIntoSet(bindTo = [BaseHandler::class])
+class MyHandler @Inject constructor() : AbstractHandler()
+```
+
+`bindTo` accepts any transitive supertype. An error is emitted at compile time
+if a listed type is not a supertype of the annotated class.
 
 ## Generated Code
 

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/AutoBindingSymbolProcessor.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/AutoBindingSymbolProcessor.kt
@@ -18,6 +18,7 @@ import com.uandcode.hilt.autobind.compiler.generators.DefaultModuleGenerator
 import com.uandcode.hilt.autobind.compiler.generators.DelegateFactoryModuleGenerator
 import com.uandcode.hilt.autobind.compiler.generators.IntoSetModuleGenerator
 import com.uandcode.hilt.autobind.compiler.generators.MetadataGenerator
+import com.uandcode.hilt.autobind.compiler.resolver.AnnotatedSymbolsResolver
 
 class AutoBindingSymbolProcessor(
     private val logger: KSPLogger,

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/ModuleInfo.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/ModuleInfo.kt
@@ -1,6 +1,7 @@
 package com.uandcode.hilt.autobind.compiler
 
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSType
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ksp.toClassName
 
@@ -16,6 +17,7 @@ internal data class ModuleInfo(
     val annotationName: String,
     val annotationSource: KSClassDeclaration,
     val moduleNameSuffix: String = "Module",
+    val bindTargets: List<KSType>? = null,
 ) {
     val originClassName: ClassName = annotatedClass.toClassName()
     val transformedClassName: String = originClassName.simpleNames.joinToString("__")

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/DefaultModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/DefaultModuleGenerator.kt
@@ -37,7 +37,7 @@ internal class DefaultModuleGenerator(
             return null
         }
 
-        val targetSuperTypes = annotatedClass.getTargetSuperTypes()
+        val targetSuperTypes = moduleInfo.bindTargets ?: annotatedClass.getTargetSuperTypes()
         if (targetSuperTypes.isEmpty()) {
             logNoImplementedSuperTypes(annotatedClass)
             return null

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/IntoSetModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/IntoSetModuleGenerator.kt
@@ -39,7 +39,7 @@ internal class IntoSetModuleGenerator(
             return null
         }
 
-        val targetSuperTypes = annotatedClass.getTargetSuperTypes()
+        val targetSuperTypes = moduleInfo.bindTargets ?: annotatedClass.getTargetSuperTypes()
         if (targetSuperTypes.isEmpty()) {
             logNoImplementedSuperTypes(annotatedClass)
             return null

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/resolver/AnnotatedSymbolsResolver.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/resolver/AnnotatedSymbolsResolver.kt
@@ -1,6 +1,6 @@
 @file:OptIn(KspExperimental::class)
 
-package com.uandcode.hilt.autobind.compiler
+package com.uandcode.hilt.autobind.compiler.resolver
 
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getAnnotationsByType
@@ -14,6 +14,11 @@ import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.validate
 import com.uandcode.hilt.autobind.AutoBinds
 import com.uandcode.hilt.autobind.AutoBindsIntoSet
+import com.uandcode.hilt.autobind.compiler.HiltComponentResolver
+import com.uandcode.hilt.autobind.compiler.METADATA_PACKAGE
+import com.uandcode.hilt.autobind.compiler.MetadataInfo
+import com.uandcode.hilt.autobind.compiler.ModuleInfo
+import com.uandcode.hilt.autobind.compiler.ModuleType
 import com.uandcode.hilt.autobind.factories.ClassBindingFactory
 import com.uandcode.hilt.autobind.factories.DelegateBindingFactory
 import com.uandcode.hilt.autobind.factories.NoOpBindingFactory
@@ -23,6 +28,8 @@ internal class AnnotatedSymbolsResolver(
     private val logger: KSPLogger,
     private val componentResolver: HiltComponentResolver,
 ) {
+
+    private val bindTypesResolver: BindTypesResolver = BindTypesResolver(logger)
 
     fun processAnnotatedSymbols(
         resolver: Resolver,
@@ -183,6 +190,7 @@ internal class AnnotatedSymbolsResolver(
      *   Defaults to [annotatedClass] for the direct-annotation case; set to the
      *   meta-annotation declaration when the annotation was applied indirectly.
      */
+    @Suppress("ReturnCount")
     private fun processAutoBinds(
         annotatedClass: KSClassDeclaration,
         onGenerateHiltModule: (ModuleType, ModuleInfo) -> Unit,
@@ -207,6 +215,12 @@ internal class AnnotatedSymbolsResolver(
             annotationName = originAnnotationName,
         ) ?: return
 
+        val bindTargets = bindTypesResolver.findBindToKTypes(annotationSource, AUTOBINDS_NAME)
+        if (bindTargets != null &&
+                !bindTypesResolver.validateBindTargets(annotatedClass, bindTargets, originAnnotationName)) {
+            return
+        }
+
         val moduleInfo = ModuleInfo(
             annotatedClass = annotatedClass,
             hiltComponentClassName = resolved.hiltComponentClassName,
@@ -215,6 +229,7 @@ internal class AnnotatedSymbolsResolver(
             isObjectModuleRequired = resolved.isObjectModuleRequired,
             annotationSource = annotationSource,
             annotationName = originAnnotationName,
+            bindTargets = bindTargets,
         )
         val moduleType = getModuleType(annotationSource)
         if (moduleType != null) {
@@ -222,6 +237,7 @@ internal class AnnotatedSymbolsResolver(
         }
     }
 
+    @Suppress("ReturnCount")
     private fun processAutoBindsIntoSet(
         annotatedClass: KSClassDeclaration,
         onGenerateHiltModule: (ModuleType, ModuleInfo) -> Unit,
@@ -243,6 +259,12 @@ internal class AnnotatedSymbolsResolver(
             annotationName = AUTOBINDS_INTO_SET_NAME,
         ) ?: return
 
+        val bindTargets = bindTypesResolver.findBindToKTypes(annotatedClass, AUTOBINDS_INTO_SET_NAME)
+        if (bindTargets != null &&
+                !bindTypesResolver.validateBindTargets(annotatedClass, bindTargets, AUTOBINDS_INTO_SET_NAME)) {
+            return
+        }
+
         val moduleInfo = ModuleInfo(
             annotatedClass = annotatedClass,
             hiltComponentClassName = resolved.hiltComponentClassName,
@@ -251,7 +273,8 @@ internal class AnnotatedSymbolsResolver(
             moduleNameSuffix = "__IntoSetModule",
             hasScopeAnnotation = resolved.hasScopeAnnotation,
             isObjectModuleRequired = resolved.isObjectModuleRequired,
-            annotationName = requireNotNull(AutoBindsIntoSet::class.simpleName)
+            annotationName = requireNotNull(AutoBindsIntoSet::class.simpleName),
+            bindTargets = bindTargets,
         )
         onGenerateHiltModule.invoke(ModuleType.IntoSet, moduleInfo)
     }

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/resolver/BindTypesResolver.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/resolver/BindTypesResolver.kt
@@ -1,0 +1,64 @@
+package com.uandcode.hilt.autobind.compiler.resolver
+
+import com.google.devtools.ksp.getAllSuperTypes
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSType
+
+internal class BindTypesResolver(
+    private val logger: KSPLogger,
+) {
+
+    /**
+     * Reads the `bindTo` argument from an annotation, returning the list of target types,
+     * or null if the argument is absent or empty (meaning auto-detection should be used).
+     *
+     * Note: `Array<KClass<*>>` annotation arguments are represented as `List<KSType>` in KSP.
+     */
+    fun findBindToKTypes(
+        annotationSource: KSClassDeclaration,
+        annotationShortName: String,
+    ): List<KSType>? {
+        @Suppress("UNCHECKED_CAST")
+        val list = annotationSource
+            .annotations
+            .firstOrNull { it.shortName.asString() == annotationShortName }
+            ?.arguments
+            ?.firstOrNull { it.name?.asString() == BIND_TO_ARG_NAME }
+            ?.value as? List<KSType>
+        return list?.takeIf { it.isNotEmpty() }
+    }
+
+    /**
+     * Validates that every type in [bindTargets] is a transitive supertype of [annotatedClass].
+     * Emits a compile-time error for each invalid type.
+     *
+     * @return true if all types are valid, false if any are invalid.
+     */
+    fun validateBindTargets(
+        annotatedClass: KSClassDeclaration,
+        bindTargets: List<KSType>,
+        annotationName: String,
+    ): Boolean {
+        val allSuperTypeNames = annotatedClass
+            .getAllSuperTypes()
+            .mapNotNull { it.declaration.qualifiedName?.asString() }
+            .toSet()
+        var valid = true
+        for (target in bindTargets) {
+            val qualifiedName = target.declaration.qualifiedName?.asString()
+            if (qualifiedName == null || qualifiedName !in allSuperTypeNames) {
+                logger.error(
+                    "@$annotationName(bindTo=...): '${target.declaration.simpleName.asString()}' " +
+                            "is not a supertype of '${annotatedClass.simpleName.asString()}'.",
+                    annotatedClass,
+                )
+                valid = false
+            }
+        }
+        return valid
+    }
+
+}
+
+private const val BIND_TO_ARG_NAME = "bindTo"

--- a/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/BindToParameterTest.kt
+++ b/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/BindToParameterTest.kt
@@ -1,0 +1,259 @@
+package com.uandcode.hilt.autobind.compiler
+
+import com.tschuchort.compiletesting.SourceFile
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertCompilationError
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertContent
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertHasGeneratedFile
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertNoGeneratedFile
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertOk
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.compile
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class BindToParameterTest {
+
+    @Test
+    fun `bindTo empty list falls back to auto-detection`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import javax.inject.Inject
+
+            interface Repo
+
+            @AutoBinds(bindTo = [])
+            class RepoImpl @Inject constructor() : Repo
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface RepoImplModule {
+              @Binds
+              public fun bindToRepo(`impl`: RepoImpl): Repo
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `bindTo restricts bindings to specified subset of direct supertypes`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import javax.inject.Inject
+
+            interface Repo
+            interface Closeable
+
+            @AutoBinds(bindTo = [Repo::class])
+            class RepoImpl @Inject constructor() : Repo, Closeable
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface RepoImplModule {
+              @Binds
+              public fun bindToRepo(`impl`: RepoImpl): Repo
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `bindTo can target a grandparent class`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import javax.inject.Inject
+
+            interface GrandParent
+            open class Parent : GrandParent
+
+            @AutoBinds(bindTo = [GrandParent::class])
+            class Child @Inject constructor() : Parent()
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("ChildModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface ChildModule {
+              @Binds
+              public fun bindToGrandParent(`impl`: Child): GrandParent
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `bindTo with multiple targets generates bindings for each`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import javax.inject.Inject
+
+            interface Repo
+            interface Closeable
+            interface Auditable
+
+            @AutoBinds(bindTo = [Repo::class, Closeable::class])
+            class RepoImpl @Inject constructor() : Repo, Closeable, Auditable
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface RepoImplModule {
+              @Binds
+              public fun bindToRepo(`impl`: RepoImpl): Repo
+
+              @Binds
+              public fun bindToCloseable(`impl`: RepoImpl): Closeable
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `error when bindTo targets a non-supertype`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import javax.inject.Inject
+
+            interface Repo
+            interface Unrelated
+
+            @AutoBinds(bindTo = [Unrelated::class])
+            class RepoImpl @Inject constructor() : Repo
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertCompilationError()
+        assertTrue(result.messages.contains("is not a supertype of 'RepoImpl'"))
+    }
+
+    @Test
+    fun `error when bindTo targets a non-supertype does not generate module`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import javax.inject.Inject
+
+            interface Repo
+            interface Unrelated
+
+            @AutoBinds(bindTo = [Unrelated::class])
+            class RepoImpl @Inject constructor() : Repo
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertCompilationError()
+        result.assertNoGeneratedFile("RepoImplModule.kt")
+    }
+
+    @Test
+    fun `bindTo on AutoBindsIntoSet targets grandparent`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBindsIntoSet
+            import javax.inject.Inject
+
+            interface GrandParent
+            open class Parent : GrandParent
+
+            @AutoBindsIntoSet(bindTo = [GrandParent::class])
+            class Child @Inject constructor() : Parent()
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("Child__IntoSetModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import dagger.multibindings.IntoSet
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface Child__IntoSetModule {
+              @Binds
+              @IntoSet
+              public fun bindToGrandParent(`impl`: Child): GrandParent
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `error when AutoBindsIntoSet bindTo targets a non-supertype`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBindsIntoSet
+            import javax.inject.Inject
+
+            interface Interceptor
+            interface Unrelated
+
+            @AutoBindsIntoSet(bindTo = [Unrelated::class])
+            class LoggingInterceptor @Inject constructor() : Interceptor
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertCompilationError()
+        assertTrue(result.messages.contains("is not a supertype of 'LoggingInterceptor'"))
+    }
+}

--- a/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/MetaAnnotationBindingTest.kt
+++ b/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/MetaAnnotationBindingTest.kt
@@ -489,4 +489,109 @@ class MetaAnnotationBindingTest {
         result.assertCompilationError()
         assertTrue(result.messages.contains("different scopes"))
     }
+
+    @Test
+    fun `bindTo on meta-annotation restricts bindings to specified subset of supertypes`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import javax.inject.Inject
+
+            interface Repo
+            interface Closeable
+
+            @Target(AnnotationTarget.CLASS)
+            @AutoBinds(bindTo = [Repo::class])
+            annotation class BindToRepo
+
+            @BindToRepo
+            class RepoImpl @Inject constructor() : Repo, Closeable
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface RepoImplModule {
+              @Binds
+              public fun bindToRepo(`impl`: RepoImpl): Repo
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `bindTo on meta-annotation can target a grandparent class`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import javax.inject.Inject
+
+            interface GrandParent
+            open class Parent : GrandParent
+
+            @Target(AnnotationTarget.CLASS)
+            @AutoBinds(bindTo = [GrandParent::class])
+            annotation class BindToGrandParent
+
+            @BindToGrandParent
+            class Child @Inject constructor() : Parent()
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("ChildModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Binds
+            import dagger.Module
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal interface ChildModule {
+              @Binds
+              public fun bindToGrandParent(`impl`: Child): GrandParent
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `error when bindTo on meta-annotation targets a non-supertype of the annotated class`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import javax.inject.Inject
+
+            interface Repo
+            interface Unrelated
+
+            @Target(AnnotationTarget.CLASS)
+            @AutoBinds(bindTo = [Unrelated::class])
+            annotation class BindToUnrelated
+
+            @BindToUnrelated
+            class RepoImpl @Inject constructor() : Repo
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertCompilationError()
+        assertTrue(result.messages.contains("is not a supertype of 'RepoImpl'"))
+    }
+
 }

--- a/lib-core/src/main/java/com/uandcode/hilt/autobind/AutoBinds.kt
+++ b/lib-core/src/main/java/com/uandcode/hilt/autobind/AutoBinds.kt
@@ -37,10 +37,15 @@ import kotlin.reflect.KClass
  *   Defaults to [HiltComponent.Unspecified], which auto-detects the component from
  *   the scope annotation on the class (falls back to [HiltComponent.Singleton] if unscoped).
  * @param factory optional [BindingFactory] to use for creating instances.
+ * @param bindTo explicit list of supertypes to bind to. When non-empty, only the listed
+ *   types are used as binding targets instead of all direct supertypes. Each type must be
+ *   a transitive supertype of the annotated class; a compile-time error is emitted otherwise.
+ *   Supports grandparent classes and interfaces that are not direct supertypes.
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.ANNOTATION_CLASS)
 @Retention(AnnotationRetention.BINARY)
 public annotation class AutoBinds(
     val installIn: HiltComponent = HiltComponent.Unspecified,
     val factory: KClass<out BindingFactory> = NoOpBindingFactory::class,
+    val bindTo: Array<KClass<*>> = [],
 )

--- a/lib-core/src/main/java/com/uandcode/hilt/autobind/AutoBindsIntoSet.kt
+++ b/lib-core/src/main/java/com/uandcode/hilt/autobind/AutoBindsIntoSet.kt
@@ -1,5 +1,7 @@
 package com.uandcode.hilt.autobind
 
+import kotlin.reflect.KClass
+
 /**
  * Generates a Dagger Hilt module that contributes the annotated class into a
  * multibinding `Set` of each directly implemented interface.
@@ -28,9 +30,13 @@ package com.uandcode.hilt.autobind
  * @param installIn the Hilt component to install the generated module in.
  *   Defaults to [HiltComponent.Unspecified], which auto-detects the component from
  *   the scope annotation on the class (falls back to [HiltComponent.Singleton] if unscoped).
+ * @param bindTo explicit list of supertypes to contribute to. When non-empty, only the listed
+ *   types are used instead of all direct supertypes. Each type must be a transitive supertype
+ *   of the annotated class; a compile-time error is emitted otherwise.
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
 public annotation class AutoBindsIntoSet(
     val installIn: HiltComponent = HiltComponent.Unspecified,
+    val bindTo: Array<KClass<*>> = [],
 )


### PR DESCRIPTION
Allow explicitly listing the supertypes to bind to instead of auto-detecting all direct supertypes. Accepts any super-types (direct and indirect) and emits a compile-time error if any specified type is not a transitive supertype of the annotated class. Works with both direct usage and annotation aliases.