### PR TITLE
feat: Auto-binding for object types

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Add dependencies to your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.uandcode:hilt-autobind:0.7.0")
-    ksp("com.uandcode:hilt-autobind-compiler:0.7.0")
+    implementation("com.uandcode:hilt-autobind:0.8.0")
+    ksp("com.uandcode:hilt-autobind-compiler:0.8.0")
 }
 ```
 
@@ -65,6 +65,7 @@ Manual modules are not needed anymore, and Hilt can now inject `UserRepository` 
 | Feature                                              | Annotation / parameter          | Description                                                                         |
 |------------------------------------------------------|---------------------------------|-------------------------------------------------------------------------------------|
 | [Basic binding](docs/basic-usage.md)                 | `@AutoBinds`                    | Generates `@Binds` modules for interface implementations                            |
+| [Object binding](docs/basic-usage.md#object-binding) | `@AutoBinds`                    | Generates `@Provides` modules for Kotlin `object` declarations                      |
 | [Scopes & components](docs/scopes-and-components.md) | `installIn`                     | Auto-detects or explicitly sets the Hilt component                                  |
 | [Custom components](docs/custom-components.md)       | `installInCustomComponent`      | Installs bindings into custom Hilt components defined with `@DefineComponent`       |
 | [Class factory](docs/class-factory.md)               | `@AutoBinds(factory = ...)`     | Delegates instance creation to a `ClassBindingFactory` (e.g., Retrofit)             |
@@ -85,6 +86,7 @@ Manual modules are not needed anymore, and Hilt can now inject `UserRepository` 
 | **Supertype selection**              | ✅                                                                    | ✅                                                     | ✅                                                           |
 | **Multibinding**                     | ✅                                                                    | ✅                                                     | ❌                                                           |
 | **Custom Hilt components**           | ✅                                                                    | ✅                                                     | ✅                                                           |
+| **Kotlin `object` binding**          | ✅                                                                    | ❌                                                     | ❌                                                           |
 | **Auto-binding to multiple types**   | ✅                                                                    | ❌                                                     | ❌                                                           |
 | **Combine basic-/multi- binding**    | ✅                                                                    | ❌                                                     | ❌                                                           |
 | **Binding by class (e.g. Retrofit)** | ✅                                                                    | ❌                                                     | ❌                                                           |

--- a/docs/annotation-aliases.md
+++ b/docs/annotation-aliases.md
@@ -347,7 +347,7 @@ scope annotations — are forwarded the same way as with `@AutoBinds` aliases.
 An annotation used as an `@AutoBinds`, `@AutoBindsIntoSet`, or `@AutoBindsIntoMap` alias must:
 
 - Be an **annotation class** (declared with the `annotation class` keyword).
-- Declare **`@Target(AnnotationTarget.CLASS)`** so it can be applied to classes and interfaces.
+- Declare **`@Target(AnnotationTarget.CLASS)`** so it can be applied to classes, objects, and interfaces.
 - Carry `@AutoBinds` or `@AutoBindsIntoSet` (with any desired parameters) directly on its declaration.
 
 The processor emits a compile-time error if `@Target(AnnotationTarget.CLASS)` is

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -6,15 +6,16 @@
 - [Multiple interfaces](#multiple-interfaces)
 - [Generic interfaces](#generic-interfaces)
 - [Parent class binding](#parent-class-binding)
+- [Object binding](#object-binding)
 - [Selecting specific binding targets](#selecting-specific-binding-targets)
 - [Qualifier annotations](#qualifier-annotations)
 - [How it works](#how-it-works)
-- [Requirements for annotated classes](#requirements-for-annotated-classes)
+- [Requirements for annotated classes and objects](#requirements-for-annotated-classes-and-objects)
 
 ## Single Interface Binding
 
-Annotate a concrete class that implements an interface or extends a base class with `@AutoBinds`, 
-and the processor generates a Hilt `@Binds` module automatically.
+Annotate a concrete class or Kotlin `object` that implements an interface or extends a base class
+with `@AutoBinds`, and the processor generates a Hilt module automatically.
 
 ```kotlin
 interface UserRepository {
@@ -138,6 +139,37 @@ class HomeService @Inject constructor() : BaseService(), Trackable
 This generates a single module with `@Binds` functions for both `BaseService`
 and `Trackable`.
 
+## Object Binding
+
+Kotlin `object` declarations are supported. Since objects are singletons managed
+by the language itself, no `@Inject` constructor is needed. The processor
+generates `@Provides` functions (instead of `@Binds`) that return the object
+instance directly:
+
+```kotlin
+interface Navigator
+
+@AutoBinds
+object NoOpNavigator : Navigator
+```
+
+**Generated code:**
+
+```kotlin
+@Module
+@InstallIn(SingletonComponent::class)
+internal object NoOpNavigatorModule {
+    @Provides
+    fun bindToNavigator(): Navigator = NoOpNavigator
+}
+```
+
+This is useful for stateless implementations like no-op stubs, or default strategies.
+
+All features work with objects in the same way as with classes: `installIn`,
+`bindTo`, qualifiers, scopes, custom components, and annotation aliases. Objects
+also work with `@AutoBindsIntoSet` and `@AutoBindsIntoMap`.
+
 ## Selecting Specific Binding Targets
 
 By default, `@AutoBinds` generates a binding for every direct supertype. Use
@@ -192,26 +224,34 @@ Custom `@Qualifier` annotations are supported in the same way. See
 ## How It Works
 
 Hilt AutoBind is a [KSP](https://github.com/google/ksp) annotation processor
-that runs at compile time. For each class annotated with `@AutoBinds`, it:
+that runs at compile time. For each class or object annotated with `@AutoBinds`, it:
 
 1. Finds all direct supertypes (implemented interfaces and extended parent
    classes, excluding `Any`).
-2. Generates an `internal interface` Hilt module with a `@Binds` function for
-   each supertype.
-3. Installs the module in the appropriate Hilt component (see
+2. For **classes**: generates an `internal interface` Hilt module with a `@Binds`
+   function for each supertype.
+3. For **objects**: generates an `internal object` Hilt module with a `@Provides`
+   function for each supertype, returning the object instance directly.
+4. Installs the module in the appropriate Hilt component (see
    [Scopes and Components](scopes-and-components.md)).
 
 The generated modules are `internal`, so they don't pollute your module's
 public API.
 
-## Requirements for Annotated Classes
+## Requirements for Annotated Classes and Objects
 
-A class annotated with `@AutoBinds` (in default mode, without a `factory`) must:
+A **class** annotated with `@AutoBinds` (in default mode, without a `factory`) must:
 
-- Be a **concrete class** (not an interface, object, or enum).
+- Be a **concrete class** (not an interface or enum).
 - Be **non-abstract** (no `abstract` modifier).
 - **Not be an inner class** (no `inner` modifier).
 - Have a **primary constructor annotated with `@Inject`**.
 - Implement **at least one interface** or extend a **non-`Any` parent class**.
+
+A Kotlin **object** annotated with `@AutoBinds` must:
+
+- Implement **at least one interface** or extend a **non-`Any` parent class**.
+- **Not** use the `factory` parameter (objects are their own instances and do not
+  need a factory).
 
 The processor emits a compile-time error if any of these conditions are not met.

--- a/docs/custom-components.md
+++ b/docs/custom-components.md
@@ -51,4 +51,5 @@ class RepositoryImpl @Inject constructor() : Repository
 - A custom scope annotation with no matching `@DefineComponent` class -> compile error with a hint
   to use `installInCustomComponent` explicitly.
 - All other features (qualifiers, `bindTo`, annotation aliases, `@AutoBindsIntoSet`,
-  `@AutoBindsIntoMap`) work with custom components identically to standard Hilt components.
+  `@AutoBindsIntoMap`, Kotlin `object` declarations) work with custom components
+  identically to standard Hilt components.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -65,8 +65,8 @@ Add the library and the KSP compiler to your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.uandcode:hilt-autobind:0.7.0")
-    ksp("com.uandcode:hilt-autobind-compiler:0.7.0")
+    implementation("com.uandcode:hilt-autobind:0.8.0")
+    ksp("com.uandcode:hilt-autobind-compiler:0.8.0")
 }
 ```
 
@@ -76,7 +76,7 @@ If your project uses a Gradle version catalog (`libs.versions.toml`):
 
 ```toml
 [versions]
-hiltAutoBind = "0.7.0"
+hiltAutoBind = "0.8.0"
 
 [libraries]
 hilt-autobind = { module = "com.uandcode:hilt-autobind", version.ref = "hiltAutoBind" }

--- a/docs/multibinding-map.md
+++ b/docs/multibinding-map.md
@@ -14,10 +14,10 @@
 
 ## Overview
 
-Use `@AutoBindsIntoMap` to contribute a class into a Dagger multibinding `Map`.
-Each contribution requires a map key annotation (e.g. `@StringKey`, `@IntKey`,
-`@ClassKey`, or any custom `@MapKey` annotation). The processor forwards the
-key annotation to the generated `@Binds @IntoMap` function.
+Use `@AutoBindsIntoMap` to contribute a class or Kotlin `object` into a Dagger
+multibinding `Map`. Each contribution requires a map key annotation (e.g.
+`@StringKey`, `@IntKey`, `@ClassKey`, or any custom `@MapKey` annotation). The
+processor forwards the key annotation to the generated binding function.
 
 ## Contributing to a Map
 
@@ -183,7 +183,7 @@ if a listed type is not a supertype of the annotated class.
 
 ## Generated Code
 
-For each annotated class, the processor generates an `interface` Hilt module
+For each annotated **class**, the processor generates an `interface` Hilt module
 with `@Binds @IntoMap` functions:
 
 ```kotlin
@@ -194,6 +194,20 @@ internal interface LoggingInterceptor__IntoMapModule {
     @IntoMap
     @StringKey("logging")
     fun bindToInterceptor(impl: LoggingInterceptor): Interceptor
+}
+```
+
+For each annotated **object**, the processor generates an `object` Hilt module
+with `@Provides @IntoMap` functions:
+
+```kotlin
+@Module
+@InstallIn(SingletonComponent::class)
+internal object NoOpInterceptor__IntoMapModule {
+    @Provides
+    @IntoMap
+    @StringKey("noop")
+    fun bindToInterceptor(): Interceptor = NoOpInterceptor
 }
 ```
 
@@ -210,6 +224,5 @@ internal interface LoggingInterceptor__IntoMapModule {
 }
 ```
 
-The same class requirements as [basic usage](basic-usage.md#requirements-for-annotated-classes)
-apply: the class must be concrete, non-abstract, not an inner class, have `@Inject` on its
-primary constructor, and implement at least one interface or extend a parent class.
+The same requirements as [basic usage](basic-usage.md#requirements-for-annotated-classes-and-objects)
+apply.

--- a/docs/multibinding-set.md
+++ b/docs/multibinding-set.md
@@ -11,10 +11,10 @@
 
 ## Overview
 
-Use `@AutoBindsIntoSet` to contribute a class into a Dagger multibinding `Set`
-of each direct supertype (implemented interfaces and extended parent classes).
-This lets you collect multiple implementations automatically without maintaining
-a manual module.
+Use `@AutoBindsIntoSet` to contribute a class or Kotlin `object` into a Dagger
+multibinding `Set` of each direct supertype (implemented interfaces and extended
+parent classes). This lets you collect multiple implementations automatically
+without maintaining a manual module.
 
 ## Contributing to a Set
 
@@ -99,7 +99,7 @@ if a listed type is not a supertype of the annotated class.
 
 ## Generated Code
 
-For each annotated class, the processor generates an `interface` Hilt module
+For each annotated **class**, the processor generates an `interface` Hilt module
 with `@Binds @IntoSet` functions:
 
 ```kotlin
@@ -111,6 +111,17 @@ internal interface LoggingInterceptor__IntoSetModule {
 }
 ```
 
-The same class requirements as [basic usage](basic-usage.md#requirements-for-annotated-classes)
-apply: the class must be concrete, non-abstract, not an inner class, have `@Inject` on its
-primary constructor, and implement at least one interface or extend a parent class.
+For each annotated **object**, the processor generates an `object` Hilt module
+with `@Provides @IntoSet` functions:
+
+```kotlin
+@Module
+@InstallIn(SingletonComponent::class)
+internal object NoOpInterceptor__IntoSetModule {
+    @Provides @IntoSet
+    fun bindToInterceptor(): Interceptor = NoOpInterceptor
+}
+```
+
+The same requirements as [basic usage](basic-usage.md#requirements-for-annotated-classes-and-objects)
+apply.

--- a/docs/qualifiers.md
+++ b/docs/qualifiers.md
@@ -20,7 +20,8 @@ When two classes implement the same interface but should be injected in differen
 a qualifier annotation tells Hilt (and Dagger) which binding to use.
 
 The annotation processor forwards any qualifier annotation found on the annotated class
-(or its alias) directly to the generated binding function. No extra configuration is needed.
+or object (or its alias) directly to the generated binding function. No extra configuration
+is needed.
 
 ## Using `@Named` qualifier
 

--- a/docs/scopes-and-components.md
+++ b/docs/scopes-and-components.md
@@ -45,7 +45,7 @@ class SearchRepository @Inject constructor(
 ```
 
 This works with all `@AutoBinds`, `@AutoBindsIntoSet`, and `@AutoBindsIntoMap`
-annotations.
+annotations, including when applied to Kotlin `object` declarations.
 
 ## Scope Validation
 

--- a/gradle-public.properties
+++ b/gradle-public.properties
@@ -5,7 +5,7 @@ android.useAndroidX=true
 
 # Maven Central publishing coordinates
 GROUP=com.uandcode
-VERSION_NAME=0.7.0
+VERSION_NAME=0.8.0
 
 # POM metadata
 POM_DESCRIPTION=Auto-generate Hilt binding modules with a single annotation

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/ModuleInfo.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/ModuleInfo.kt
@@ -9,7 +9,7 @@ import com.squareup.kotlinpoet.ksp.toClassName
 /**
  * Holds naming information for the generated Hilt module.
  */
-internal data class ModuleInfo constructor(
+internal data class ModuleInfo(
     val annotatedClass: KSClassDeclaration,
     val annotationName: String,
     val annotationSource: KSClassDeclaration,

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/ModuleType.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/ModuleType.kt
@@ -9,14 +9,19 @@ import com.squareup.kotlinpoet.AnnotationSpec
 internal sealed class ModuleType {
 
     /** Generate an interface with `@Binds` functions. */
-    data object Default : ModuleType()
+    data class Default(
+        val isObject: Boolean,
+    ) : ModuleType()
 
     /** Generate an interface with `@Binds` and `@IntoSet` functions. */
-    data object IntoSet : ModuleType()
+    data class IntoSet(
+        val isObject: Boolean,
+    ) : ModuleType()
 
     /** Generate an interface with `@Binds`, `@IntoMap`, and a map key annotation functions. */
     data class IntoMap(
         val mapKeyAnnotationSpec: AnnotationSpec,
+        val isObject: Boolean,
     ) : ModuleType()
 
     /** Generate an object with a `@Provides` function that delegates to a factory. */

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/AbstractModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/AbstractModuleGenerator.kt
@@ -10,9 +10,7 @@ import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.Modifier
-import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.TypeName
-import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.uandcode.hilt.autobind.compiler.AutoBindException
@@ -60,22 +58,15 @@ internal abstract class AbstractModuleGenerator(
     protected fun ModuleInfo.superTypesNotFoundException(annotatedClass: KSClassDeclaration) =
         commonKspException("must implement at least one interface or extend a super-class", annotatedClass)
 
-    protected fun FunSpec.Builder.applyQualifier(
-        moduleInfo: ModuleInfo,
-    ) = apply {
-        if (moduleInfo.qualifier != null) {
-            addAnnotation(moduleInfo.qualifier.toAnnotationSpec())
-        }
-    }
-
     /**
      * @return The list of target super-types for which binding modules
      *   must be generated.
      */
     protected fun ModuleInfo.validateCommonBindingRules(): List<KSType> {
-        if (annotatedClass.classKind != ClassKind.CLASS) {
-            throw commonKspException("must be a class (not object, interface, etc.)", annotatedClass)
+        if (annotatedClass.classKind != ClassKind.CLASS && annotatedClass.classKind != ClassKind.OBJECT) {
+            throw commonKspException("must be a class or object (not interface, etc.)", annotatedClass)
         }
+        val isInjectRequired = annotatedClass.classKind != ClassKind.OBJECT
 
         if (Modifier.INNER in annotatedClass.modifiers) {
             throw commonKspException("must not be an inner class (remove the 'inner' keyword)", annotatedClass)
@@ -90,11 +81,16 @@ internal abstract class AbstractModuleGenerator(
             throw commonKspException("must be a non-abstract class", annotatedClass)
         }
 
-        val hasInjectAnnotation = annotatedClass
-            .primaryConstructor
-            ?.isAnnotationPresent(Inject::class)
-        if (hasInjectAnnotation != true) {
-            throw commonKspException("must have a primary constructor with @Inject annotation", annotatedClass)
+        if (isInjectRequired) {
+            val hasInjectAnnotation = annotatedClass
+                .primaryConstructor
+                ?.isAnnotationPresent(Inject::class)
+            if (hasInjectAnnotation != true) {
+                throw commonKspException(
+                    "must have a primary constructor with @Inject annotation",
+                    annotatedClass
+                )
+            }
         }
 
         return targetSuperTypes

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/DefaultModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/DefaultModuleGenerator.kt
@@ -6,11 +6,8 @@ import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSType
 import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeSpec
 import com.uandcode.hilt.autobind.compiler.ModuleInfo
-import dagger.Binds
 
 /**
  * Generates an interface-based Hilt module with `@Binds` functions
@@ -20,12 +17,15 @@ internal class DefaultModuleGenerator(
     logger: KSPLogger,
 ) : AbstractModuleGenerator(logger) {
 
-    fun generate(moduleInfo: ModuleInfo): TypeSpec = with(moduleInfo) {
+    fun generate(
+        moduleInfo: ModuleInfo,
+        isObject: Boolean,
+    ): TypeSpec = with(moduleInfo) {
         val targetSuperTypes = validateCommonBindingRules()
-        return TypeSpec.interfaceBuilder(className = moduleClassName)
+        return createTypeSpecBuilder(isObject)
             .preBuildHiltModuleTypeSpec(hiltComponentClassName)
             .apply {
-                addBindFunctions(moduleInfo, originClassName, targetSuperTypes)
+                addBindFunctions(moduleInfo, originClassName, targetSuperTypes, isObject)
             }
             .build()
     }
@@ -34,21 +34,11 @@ internal class DefaultModuleGenerator(
         moduleInfo: ModuleInfo,
         originClassName: ClassName,
         targetSuperTypes: List<KSType>,
-    ) = forEachTargetSuperType(moduleInfo, targetSuperTypes) {
-        val funSpec = FunSpec.builder(it.functionName)
-            .addParameter(name = "impl", type = originClassName)
-            .addAnnotation(Binds::class)
-            .apply {
-                val scope = moduleInfo.scopeClassName
-                if (moduleInfo.isScopedBindingRequired && scope != null) {
-                    addAnnotation(scope)
-                }
-            }
-            .applyQualifier(moduleInfo)
-            .addModifiers(KModifier.ABSTRACT)
-            .returns(it.supertypeTypeName)
+        isObject: Boolean,
+    ) = forEachTargetSuperType(moduleInfo, targetSuperTypes) { targetSuperType ->
+        preBuildBinder(moduleInfo, targetSuperType, originClassName, isObject)
             .build()
-        addFunction(funSpec)
+            .let(::addFunction)
     }
 
 }

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/HiltModuleAnnotations.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/HiltModuleAnnotations.kt
@@ -2,9 +2,16 @@ package com.uandcode.hilt.autobind.compiler.generators
 
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.ksp.toAnnotationSpec
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.uandcode.hilt.autobind.compiler.ModuleInfo
+import com.uandcode.hilt.autobind.compiler.generators.AbstractModuleGenerator.TargetSuperType
+import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 
 /**
@@ -20,4 +27,49 @@ internal fun TypeSpec.Builder.preBuildHiltModuleTypeSpec(
             .build()
     )
     addModifiers(KModifier.INTERNAL)
+}
+
+
+internal fun ModuleInfo.createTypeSpecBuilder(
+    isObject: Boolean,
+): TypeSpec.Builder {
+    return if (isObject) {
+        TypeSpec.objectBuilder(className = moduleClassName)
+    } else {
+        TypeSpec.interfaceBuilder(className = moduleClassName)
+    }
+}
+
+internal fun preBuildBinder(
+    moduleInfo: ModuleInfo,
+    targetSupertype: TargetSuperType,
+    originClassName: ClassName,
+    isObject: Boolean,
+): FunSpec.Builder {
+    return FunSpec.builder(targetSupertype.functionName)
+        .addAnnotation(if (isObject) Provides::class else Binds::class)
+        .apply {
+            if (!isObject) {
+                addParameter(name = "impl", type = originClassName)
+                addModifiers(KModifier.ABSTRACT)
+            } else {
+                addCode("return %T", moduleInfo.annotatedClass.toClassName())
+            }
+        }
+        .applyQualifier(moduleInfo)
+        .apply {
+            val scope = moduleInfo.scopeClassName
+            if (moduleInfo.isScopedBindingRequired && scope != null) {
+                addAnnotation(scope)
+            }
+        }
+        .returns(targetSupertype.supertypeTypeName)
+}
+
+internal fun FunSpec.Builder.applyQualifier(
+    moduleInfo: ModuleInfo,
+) = apply {
+    if (moduleInfo.qualifier != null) {
+        addAnnotation(moduleInfo.qualifier.toAnnotationSpec())
+    }
 }

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/HiltModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/HiltModuleGenerator.kt
@@ -26,9 +26,13 @@ internal class HiltModuleGenerator(
         moduleInfo: ModuleInfo
     ) {
         val typeSpec = when (type) {
-            is ModuleType.Default -> defaultModuleGenerator.generate(moduleInfo)
-            is ModuleType.IntoSet -> intoSetModuleGenerator.generate(moduleInfo)
-            is ModuleType.IntoMap -> intoMapModuleGenerator.generate(moduleInfo, type.mapKeyAnnotationSpec)
+            is ModuleType.Default -> defaultModuleGenerator.generate(moduleInfo, type.isObject)
+            is ModuleType.IntoSet -> intoSetModuleGenerator.generate(moduleInfo, type.isObject)
+            is ModuleType.IntoMap -> intoMapModuleGenerator.generate(
+                moduleInfo = moduleInfo,
+                mapKeyAnnotationSpec = type.mapKeyAnnotationSpec,
+                isObject = type.isObject,
+            )
             is ModuleType.ClassFactory -> classFactoryModuleGenerator.generate(
                 moduleInfo = moduleInfo,
                 factoryDeclaration = type.factoryDeclaration,

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/IntoMapModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/IntoMapModuleGenerator.kt
@@ -7,11 +7,8 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSType
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeSpec
 import com.uandcode.hilt.autobind.compiler.ModuleInfo
-import dagger.Binds
 import dagger.multibindings.IntoMap
 
 /**
@@ -23,13 +20,16 @@ internal class IntoMapModuleGenerator(
     logger: KSPLogger,
 ) : AbstractModuleGenerator(logger = logger) {
 
-    fun generate(moduleInfo: ModuleInfo, mapKeyAnnotationSpec: AnnotationSpec): TypeSpec = with(moduleInfo) {
+    fun generate(
+        moduleInfo: ModuleInfo,
+        mapKeyAnnotationSpec: AnnotationSpec,
+        isObject: Boolean,
+    ): TypeSpec = with(moduleInfo) {
         val targetSuperTypes = validateCommonBindingRules()
-        return TypeSpec
-            .interfaceBuilder(className = moduleClassName)
+        return createTypeSpecBuilder(isObject)
             .preBuildHiltModuleTypeSpec(hiltComponentClassName)
             .apply {
-                addBindIntoMapFunctions(moduleInfo, originClassName, targetSuperTypes, mapKeyAnnotationSpec)
+                addBindIntoMapFunctions(moduleInfo, originClassName, targetSuperTypes, mapKeyAnnotationSpec, isObject)
             }
             .build()
     }
@@ -39,23 +39,13 @@ internal class IntoMapModuleGenerator(
         originClassName: ClassName,
         targetSuperTypes: List<KSType>,
         mapKeyAnnotationSpec: AnnotationSpec,
-    ) = forEachTargetSuperType(moduleInfo, targetSuperTypes) {
-        val funSpec = FunSpec.builder(it.functionName)
-            .addParameter(name = "impl", type = originClassName)
-            .addAnnotation(Binds::class)
+        isObject: Boolean,
+    ) = forEachTargetSuperType(moduleInfo, targetSuperTypes) { targetSuperType ->
+        preBuildBinder(moduleInfo, targetSuperType, originClassName, isObject)
             .addAnnotation(IntoMap::class)
             .addAnnotation(mapKeyAnnotationSpec)
-            .apply {
-                val scope = moduleInfo.scopeClassName
-                if (moduleInfo.isScopedBindingRequired && scope != null) {
-                    addAnnotation(scope)
-                }
-            }
-            .applyQualifier(moduleInfo)
-            .addModifiers(KModifier.ABSTRACT)
-            .returns(it.supertypeTypeName)
             .build()
-        addFunction(funSpec)
+            .let(::addFunction)
     }
 
 }

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/IntoSetModuleGenerator.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/generators/IntoSetModuleGenerator.kt
@@ -6,11 +6,8 @@ import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSType
 import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeSpec
 import com.uandcode.hilt.autobind.compiler.ModuleInfo
-import dagger.Binds
 import dagger.multibindings.IntoSet
 
 /**
@@ -22,13 +19,15 @@ internal class IntoSetModuleGenerator(
     logger: KSPLogger,
 ) : AbstractModuleGenerator(logger = logger) {
 
-    fun generate(moduleInfo: ModuleInfo): TypeSpec = with(moduleInfo) {
+    fun generate(
+        moduleInfo: ModuleInfo,
+        isObject: Boolean,
+    ): TypeSpec = with(moduleInfo) {
         val targetSuperTypes = validateCommonBindingRules()
-        return TypeSpec
-            .interfaceBuilder(className = moduleClassName)
+        return createTypeSpecBuilder(isObject)
             .preBuildHiltModuleTypeSpec(hiltComponentClassName)
             .apply {
-                addBindIntoSetFunctions(moduleInfo, originClassName, targetSuperTypes)
+                addBindIntoSetFunctions(moduleInfo, originClassName, targetSuperTypes, isObject)
             }
             .build()
     }
@@ -37,22 +36,12 @@ internal class IntoSetModuleGenerator(
         moduleInfo: ModuleInfo,
         originClassName: ClassName,
         targetSuperTypes: List<KSType>,
-    ) = forEachTargetSuperType(moduleInfo, targetSuperTypes) {
-        val funSpec = FunSpec.builder(it.functionName)
-            .addParameter(name = "impl", type = originClassName)
-            .addAnnotation(Binds::class)
+        isObject: Boolean,
+    ) = forEachTargetSuperType(moduleInfo, targetSuperTypes) { targetSuperType ->
+        preBuildBinder(moduleInfo, targetSuperType, originClassName, isObject)
             .addAnnotation(IntoSet::class)
-            .apply {
-                val scope = moduleInfo.scopeClassName
-                if (moduleInfo.isScopedBindingRequired && scope != null) {
-                    addAnnotation(scope)
-                }
-            }
-            .applyQualifier(moduleInfo)
-            .addModifiers(KModifier.ABSTRACT)
-            .returns(it.supertypeTypeName)
             .build()
-        addFunction(funSpec)
+            .let(::addFunction)
     }
 
 }

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/resolver/AutoBindsIntoMapResolver.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/resolver/AutoBindsIntoMapResolver.kt
@@ -4,6 +4,7 @@ package com.uandcode.hilt.autobind.compiler.resolver
 
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getAnnotationsByType
+import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.uandcode.hilt.autobind.AutoBindsIntoMap
 import com.uandcode.hilt.autobind.compiler.AutoBindException
@@ -73,7 +74,8 @@ internal class AutoBindsIntoMapResolver(
             annotationName = originAnnotationName,
             bindTargets = bindTargets,
         )
-        generator.generateHiltModule(ModuleType.IntoMap(mapKeyAnnotationSpec), moduleInfo)
+        val isObject = annotatedClass.classKind == ClassKind.OBJECT
+        generator.generateHiltModule(ModuleType.IntoMap(mapKeyAnnotationSpec, isObject), moduleInfo)
     }
 
 }

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/resolver/AutoBindsIntoSetResolver.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/resolver/AutoBindsIntoSetResolver.kt
@@ -4,6 +4,7 @@ package com.uandcode.hilt.autobind.compiler.resolver
 
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getAnnotationsByType
+import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.uandcode.hilt.autobind.AutoBindsIntoSet
 import com.uandcode.hilt.autobind.compiler.AutoBindException
@@ -65,6 +66,7 @@ internal class AutoBindsIntoSetResolver(
             annotationName = originAnnotationName,
             bindTargets = bindTargets,
         )
-        generator.generateHiltModule(ModuleType.IntoSet, moduleInfo)
+        val isObject = annotatedClass.classKind == ClassKind.OBJECT
+        generator.generateHiltModule(ModuleType.IntoSet(isObject), moduleInfo)
     }
 }

--- a/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/resolver/AutoBindsResolver.kt
+++ b/lib-compiler/src/main/java/com/uandcode/hilt/autobind/compiler/resolver/AutoBindsResolver.kt
@@ -4,6 +4,7 @@ package com.uandcode.hilt.autobind.compiler.resolver
 
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getAnnotationsByType
+import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.uandcode.hilt.autobind.AutoBinds
 import com.uandcode.hilt.autobind.compiler.AutoBindException
@@ -71,11 +72,15 @@ internal class AutoBindsResolver(
             annotationName = originAnnotationName,
             bindTargets = bindTargets,
         )
-        val moduleType = getModuleType(annotationSource)
+        val isObject = annotatedClass.classKind == ClassKind.OBJECT
+        val moduleType = getModuleType(annotationSource, isObject)
         generator.generateHiltModule(moduleType, moduleInfo)
     }
 
-    private fun getModuleType(annotationSource: KSClassDeclaration): ModuleType {
+    private fun getModuleType(
+        annotationSource: KSClassDeclaration,
+        isObject: Boolean,
+    ): ModuleType {
         return findFactoryKType(annotationSource, AUTOBINDS_NAME)
             ?.let { it.declaration as? KSClassDeclaration }
             ?.takeIf { it.qualifiedName?.asString() != NoOpBindingFactory::class.qualifiedName }
@@ -94,6 +99,6 @@ internal class AutoBindsResolver(
                         factoryDeclaration,
                     )
                 }
-            } ?: ModuleType.Default
+            } ?: ModuleType.Default(isObject)
     }
 }

--- a/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/MetaAnnotationIntoSetBindingTest.kt
+++ b/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/MetaAnnotationIntoSetBindingTest.kt
@@ -175,8 +175,8 @@ class MetaAnnotationIntoSetBindingTest {
             @InstallIn(ActivityComponent::class)
             internal interface MainHandler__IntoSetModule {
               @Binds
-              @IntoSet
               @ActivityScoped
+              @IntoSet
               public fun bindToHandler(`impl`: MainHandler): Handler
             }
         """.trimIndent())

--- a/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/ObjectAsTargetTest.kt
+++ b/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/ObjectAsTargetTest.kt
@@ -1,0 +1,664 @@
+package com.uandcode.hilt.autobind.compiler
+
+import com.tschuchort.compiletesting.SourceFile
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertCompilationError
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertContent
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertHasGeneratedFile
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.assertOk
+import com.uandcode.hilt.autobind.compiler.CompilationTestHelper.compile
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ObjectAsTargetTest {
+
+    @Test
+    fun `generates Provides module for simple interface`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+
+            interface UserRepository
+
+            @AutoBinds
+            object UserRepositoryImpl : UserRepository
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("UserRepositoryImplModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object UserRepositoryImplModule {
+              @Provides
+              public fun bindToUserRepository(): UserRepository = UserRepositoryImpl
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `generates Provides module for multiple interfaces`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+
+            interface Logger
+            interface Closeable
+
+            @AutoBinds
+            object LoggerImpl : Logger, Closeable
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("LoggerImplModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object LoggerImplModule {
+              @Provides
+              public fun bindToLogger(): Logger = LoggerImpl
+
+              @Provides
+              public fun bindToCloseable(): Closeable = LoggerImpl
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `uses explicit installIn Activity component`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import com.uandcode.hilt.autobind.HiltComponent
+
+            interface Repo
+
+            @AutoBinds(installIn = HiltComponent.Activity)
+            object RepoImpl : Repo
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.android.components.ActivityComponent
+
+            @Module
+            @InstallIn(ActivityComponent::class)
+            internal object RepoImplModule {
+              @Provides
+              public fun bindToRepo(): Repo = RepoImpl
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `bindTo restricts binding targets`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+
+            interface Logger
+            interface Closeable
+
+            @AutoBinds(bindTo = [Logger::class])
+            object LoggerImpl : Logger, Closeable
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("LoggerImplModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object LoggerImplModule {
+              @Provides
+              public fun bindToLogger(): Logger = LoggerImpl
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `Named qualifier is forwarded to generated Provides function`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import javax.inject.Named
+
+            interface Repo
+
+            @Named("main")
+            @AutoBinds
+            object RepoImpl : Repo
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import javax.inject.Named
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object RepoImplModule {
+              @Provides
+              @Named(`value` = "main")
+              public fun bindToRepo(): Repo = RepoImpl
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `scope annotation on alias auto-detects component and forwards scope`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import dagger.hilt.android.scopes.ActivityScoped
+
+            interface Repo
+
+            @Target(AnnotationTarget.CLASS)
+            @AutoBinds
+            @ActivityScoped
+            annotation class ContributeActivityRepo
+
+            @ContributeActivityRepo
+            object RepoImpl : Repo
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("RepoImplModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.android.components.ActivityComponent
+            import dagger.hilt.android.scopes.ActivityScoped
+
+            @Module
+            @InstallIn(ActivityComponent::class)
+            internal object RepoImplModule {
+              @Provides
+              @ActivityScoped
+              public fun bindToRepo(): Repo = RepoImpl
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `error when object has no interfaces`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+
+            @AutoBinds
+            object Standalone
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertCompilationError()
+        assertTrue(result.messages.contains(
+            "must implement at least one interface or extend a super-class"
+        ))
+    }
+
+    @Test
+    fun `generates Provides module for parent class`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+
+            open class ParentClass
+
+            @AutoBinds
+            object ChildObject : ParentClass()
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("ChildObjectModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object ChildObjectModule {
+              @Provides
+              public fun bindToParentClass(): ParentClass = ChildObject
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `generates Provides IntoSet module`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBindsIntoSet
+
+            interface Interceptor
+
+            @AutoBindsIntoSet
+            object LoggingInterceptor : Interceptor
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("LoggingInterceptor__IntoSetModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import dagger.multibindings.IntoSet
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object LoggingInterceptor__IntoSetModule {
+              @Provides
+              @IntoSet
+              public fun bindToInterceptor(): Interceptor = LoggingInterceptor
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `Named qualifier is forwarded to generated Provides IntoSet function`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBindsIntoSet
+            import javax.inject.Named
+
+            interface Interceptor
+
+            @Named("logging")
+            @AutoBindsIntoSet
+            object LoggingInterceptor : Interceptor
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("LoggingInterceptor__IntoSetModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import dagger.multibindings.IntoSet
+            import javax.inject.Named
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object LoggingInterceptor__IntoSetModule {
+              @Provides
+              @Named(`value` = "logging")
+              @IntoSet
+              public fun bindToInterceptor(): Interceptor = LoggingInterceptor
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `error when object annotated with AutoBindsIntoSet has no interfaces`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBindsIntoSet
+
+            @AutoBindsIntoSet
+            object Standalone
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertCompilationError()
+        assertTrue(result.messages.contains(
+            "must implement at least one interface or extend a super-class"
+        ))
+    }
+
+    @Test
+    fun `generates Provides IntoMap module with StringKey`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBindsIntoMap
+            import dagger.multibindings.StringKey
+
+            interface Interceptor
+
+            @AutoBindsIntoMap
+            @StringKey("logging")
+            object LoggingInterceptor : Interceptor
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("LoggingInterceptor__IntoMapModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import dagger.multibindings.IntoMap
+            import dagger.multibindings.StringKey
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object LoggingInterceptor__IntoMapModule {
+              @Provides
+              @IntoMap
+              @StringKey(`value` = "logging")
+              public fun bindToInterceptor(): Interceptor = LoggingInterceptor
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `Named qualifier is forwarded to generated Provides IntoMap function`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBindsIntoMap
+            import dagger.multibindings.StringKey
+            import javax.inject.Named
+
+            interface Interceptor
+
+            @Named("debug")
+            @AutoBindsIntoMap
+            @StringKey("logging")
+            object LoggingInterceptor : Interceptor
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("LoggingInterceptor__IntoMapModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import dagger.multibindings.IntoMap
+            import dagger.multibindings.StringKey
+            import javax.inject.Named
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object LoggingInterceptor__IntoMapModule {
+              @Provides
+              @Named(`value` = "debug")
+              @IntoMap
+              @StringKey(`value` = "logging")
+              public fun bindToInterceptor(): Interceptor = LoggingInterceptor
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `AutoBindsIntoMap scope annotation on alias auto-detects component and forwards scope`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBindsIntoMap
+            import dagger.hilt.android.scopes.ActivityScoped
+            import dagger.multibindings.StringKey
+
+            interface Handler
+
+            @Target(AnnotationTarget.CLASS)
+            @AutoBindsIntoMap
+            @ActivityScoped
+            annotation class ContributeActivityScopedHandler
+
+            @ContributeActivityScopedHandler
+            @StringKey("main")
+            object MainHandler : Handler
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        val generated = result.assertHasGeneratedFile("MainHandler__IntoMapModule.kt")
+        generated.assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.android.components.ActivityComponent
+            import dagger.hilt.android.scopes.ActivityScoped
+            import dagger.multibindings.IntoMap
+            import dagger.multibindings.StringKey
+
+            @Module
+            @InstallIn(ActivityComponent::class)
+            internal object MainHandler__IntoMapModule {
+              @Provides
+              @ActivityScoped
+              @IntoMap
+              @StringKey(`value` = "main")
+              public fun bindToHandler(): Handler = MainHandler
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `AutoBindsIntoMap error when object has no interfaces`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBindsIntoMap
+            import dagger.multibindings.StringKey
+
+            @AutoBindsIntoMap
+            @StringKey("key")
+            object Standalone
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertCompilationError()
+        assertTrue(result.messages.contains(
+            "must implement at least one interface or extend a super-class"
+        ))
+    }
+
+    @Test
+    fun `AutoBinds and AutoBindsIntoSet on same object generate separate modules`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import com.uandcode.hilt.autobind.AutoBindsIntoSet
+
+            interface Interceptor
+
+            @AutoBinds
+            @AutoBindsIntoSet
+            object DefaultInterceptor : Interceptor
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        result.assertHasGeneratedFile("DefaultInterceptorModule.kt").assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object DefaultInterceptorModule {
+              @Provides
+              public fun bindToInterceptor(): Interceptor = DefaultInterceptor
+            }
+        """.trimIndent())
+
+        result.assertHasGeneratedFile("DefaultInterceptor__IntoSetModule.kt").assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import dagger.multibindings.IntoSet
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object DefaultInterceptor__IntoSetModule {
+              @Provides
+              @IntoSet
+              public fun bindToInterceptor(): Interceptor = DefaultInterceptor
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    fun `all three annotations on same object generate all three modules`() {
+        val source = SourceFile.kotlin("Test.kt", """
+            package test
+
+            import com.uandcode.hilt.autobind.AutoBinds
+            import com.uandcode.hilt.autobind.AutoBindsIntoSet
+            import com.uandcode.hilt.autobind.AutoBindsIntoMap
+            import dagger.multibindings.StringKey
+
+            interface Interceptor
+
+            @AutoBinds
+            @AutoBindsIntoSet
+            @AutoBindsIntoMap
+            @StringKey("logging")
+            object LoggingInterceptor : Interceptor
+        """.trimIndent())
+
+        val result = compile(source)
+        result.assertOk()
+
+        result.assertHasGeneratedFile("LoggingInterceptorModule.kt").assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object LoggingInterceptorModule {
+              @Provides
+              public fun bindToInterceptor(): Interceptor = LoggingInterceptor
+            }
+        """.trimIndent())
+
+        result.assertHasGeneratedFile("LoggingInterceptor__IntoSetModule.kt").assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import dagger.multibindings.IntoSet
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object LoggingInterceptor__IntoSetModule {
+              @Provides
+              @IntoSet
+              public fun bindToInterceptor(): Interceptor = LoggingInterceptor
+            }
+        """.trimIndent())
+
+        result.assertHasGeneratedFile("LoggingInterceptor__IntoMapModule.kt").assertContent("""
+            package test
+
+            import dagger.Module
+            import dagger.Provides
+            import dagger.hilt.InstallIn
+            import dagger.hilt.components.SingletonComponent
+            import dagger.multibindings.IntoMap
+            import dagger.multibindings.StringKey
+
+            @Module
+            @InstallIn(SingletonComponent::class)
+            internal object LoggingInterceptor__IntoMapModule {
+              @Provides
+              @IntoMap
+              @StringKey(`value` = "logging")
+              public fun bindToInterceptor(): Interceptor = LoggingInterceptor
+            }
+        """.trimIndent())
+    }
+
+}

--- a/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/QualifierBindingTest.kt
+++ b/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/QualifierBindingTest.kt
@@ -178,8 +178,8 @@ class QualifierBindingTest {
             @InstallIn(SingletonComponent::class)
             internal interface RepoImplModule {
               @Binds
-              @Singleton
               @Named(`value` = "main")
+              @Singleton
               public fun bindToRepo(`impl`: RepoImpl): Repo
             }
         """.trimIndent())
@@ -300,8 +300,8 @@ class QualifierBindingTest {
             @InstallIn(SingletonComponent::class)
             internal interface LoggingInterceptor__IntoSetModule {
               @Binds
-              @IntoSet
               @Named(`value` = "logging")
+              @IntoSet
               public fun bindToInterceptor(`impl`: LoggingInterceptor): Interceptor
             }
         """.trimIndent())
@@ -348,8 +348,8 @@ class QualifierBindingTest {
             @InstallIn(SingletonComponent::class)
             internal interface MainHandler__IntoSetModule {
               @Binds
-              @IntoSet
               @HandlerQualifier
+              @IntoSet
               public fun bindToHandler(`impl`: MainHandler): Handler
             }
         """.trimIndent())

--- a/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/intomap/IntoMapBindingTest.kt
+++ b/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/intomap/IntoMapBindingTest.kt
@@ -301,9 +301,9 @@ class IntoMapBindingTest {
             @InstallIn(SingletonComponent::class)
             internal interface LoggingInterceptor__IntoMapModule {
               @Binds
+              @Named(`value` = "debug")
               @IntoMap
               @StringKey(`value` = "logging")
-              @Named(`value` = "debug")
               public fun bindToInterceptor(`impl`: LoggingInterceptor): Interceptor
             }
         """.trimIndent())
@@ -350,9 +350,9 @@ class IntoMapBindingTest {
             @InstallIn(ActivityComponent::class)
             internal interface MainHandler__IntoMapModule {
               @Binds
+              @ActivityScoped
               @IntoMap
               @StringKey(`value` = "main")
-              @ActivityScoped
               public fun bindToHandler(`impl`: MainHandler): Handler
             }
         """.trimIndent())

--- a/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/intomap/IntoMapErrorTest.kt
+++ b/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/intomap/IntoMapErrorTest.kt
@@ -116,22 +116,4 @@ class IntoMapErrorTest {
                 "annotation must implement at least one interface or extend a super-class"))
     }
 
-    @Test
-    fun `error when object is annotated instead of class`() {
-        val source = SourceFile.kotlin("Test.kt", """
-            package test
-
-            import com.uandcode.hilt.autobind.AutoBindsIntoMap
-
-            interface Handler
-
-            @AutoBindsIntoMap
-            object MyHandler : Handler
-        """.trimIndent())
-
-        val result = compile(source)
-        result.assertCompilationError()
-        assertTrue(result.messages.contains("The class 'MyHandler' annotated with @AutoBindsIntoMap " +
-                "annotation must be a class (not object, interface, etc.)"))
-    }
 }

--- a/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/intomap/MetaAnnotationIntoMapBindingTest.kt
+++ b/lib-compiler/src/test/kotlin/com/uandcode/hilt/autobind/compiler/intomap/MetaAnnotationIntoMapBindingTest.kt
@@ -289,9 +289,9 @@ class MetaAnnotationIntoMapBindingTest {
             @InstallIn(SingletonComponent::class)
             internal interface MyHandler__IntoMapModule {
               @Binds
+              @DebugHandlers
               @IntoMap
               @StringKey(`value` = "main")
-              @DebugHandlers
               public fun bindToHandler(`impl`: MyHandler): Handler
             }
         """.trimIndent())
@@ -337,9 +337,9 @@ class MetaAnnotationIntoMapBindingTest {
             @InstallIn(ActivityComponent::class)
             internal interface MainHandler__IntoMapModule {
               @Binds
+              @ActivityScoped
               @IntoMap
               @StringKey(`value` = "main")
-              @ActivityScoped
               public fun bindToHandler(`impl`: MainHandler): Handler
             }
         """.trimIndent())

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 @Suppress("UnstableApiUsage")


### PR DESCRIPTION
Kotlin `object` declarations are supported now by `@AutoBinds`, `@AutoBindsIntoSet`, and `@AutoBindsIntoMap` annotations.